### PR TITLE
perf: speed up processing of large repositories

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,7 +18,7 @@
   entry: hawkeye format
   language: python
   args: []
-  pass_filenames: false
+  pass_filenames: true
   require_serial: true
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
@@ -28,7 +28,7 @@
   entry: hawkeye format
   language: docker
   args: []
-  pass_filenames: false
+  pass_filenames: true
   require_serial: true
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Notable changes
+
+* `check`, `format`, and `remove` accept the files and directories to process as arguments, or with `--files-from <FILE>` (`-` to read them from stdin). This skips walking the whole `baseDir`, as well as the parts of the Git history that are irrelevant to those files, which is significantly faster on large repositories. Files passed explicitly are processed even if Git ignores them, and a file that was deleted and added again reports the most recent addition as `attrs.git_file_created_year`.
+* Resolving `git.attrs` is much faster: the history is traversed with an object cache, each commit is diffed against its own parent instead of against the previously visited commit, and the traversal is spread over the available cores. On a repository of 23.5k commits and 5k files, that took the traversal from 57s to 1.2s.
+
+### Bug fixes
+
+* `attrs.git_file_created_year` and `attrs.git_file_modified_year` are no longer misattributed in repositories with merge commits. The history traversal used to diff commits that are not related to each other, which reported the date of an unrelated commit for the files in between; on a repository of 23.5k commits, 2% of the files rendered a wrong year. Merge commits are now skipped, as `git log` does by default, so changes are attributed to the commit that made them.
+
 ## [6.5.1] 2026-02-14
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * `check`, `format`, and `remove` accept the files and directories to process as arguments, or with `--files-from <FILE>` (`-` to read them from stdin). This skips walking the whole `baseDir`, as well as the parts of the Git history that are irrelevant to those files, which is significantly faster on large repositories. Files passed explicitly are processed even if Git ignores them, and a file that was deleted and added again reports the most recent addition as `attrs.git_file_created_year`.
 * Resolving `git.attrs` is much faster: the history is traversed with an object cache, each commit is diffed against its own parent instead of against the previously visited commit, and the traversal is spread over the available cores. On a repository of 23.5k commits and 5k files, that took the traversal from 57s to 1.2s.
+* The `hawkeye-format` and `hawkeye-format-docker` pre-commit hooks now pass the staged files to `hawkeye`, so a commit only pays for the files it touches.
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ hawkeye check src
 git diff --name-only origin/main | hawkeye check --files-from -
 ```
 
-The paths are resolved against the `baseDir` and are still subject to the configured `includes` and
-`excludes`, so passing a file that the config skips processes nothing. Unlike a full run, passing a
-file explicitly processes it even if Git ignores it, the same way `git add --force` does. Paths that
-do not exist, which is what a diff of deleted files gives you, are skipped with a warning.
+The paths are resolved against the current directory, like any other path on the command line, and
+they are still subject to the configured `includes` and `excludes`, so passing a file that the
+config skips processes nothing. Paths outside of the `baseDir` are skipped, as are paths that do not
+exist, which is what a diff of deleted files gives you. Unlike a full run, passing a file explicitly
+processes it even if Git ignores it, the same way `git add --force` does.
 
 Note that `attrs.git_file_created_year` still requires traversing the history down to the commit
 that added a file, so the speedup is the largest either when `git.attrs` is disabled, or when the

--- a/README.md
+++ b/README.md
@@ -19,6 +19,36 @@ hawkeye remove
 
 You can use `-h` or `--help` to list out all config options.
 
+### Processing a subset of files
+
+By default, every command walks the whole `baseDir`. On large repositories, both that walk and the
+Git history traversal it may trigger can take a while, so all the commands accept the files and
+directories to process instead:
+
+```bash
+# check the given files only
+hawkeye check src/main.rs src/lib.rs
+
+# check the given directory only
+hawkeye check src
+
+# read the paths from a file, or from stdin with '-'
+git diff --name-only origin/main | hawkeye check --files-from -
+```
+
+The paths are resolved against the `baseDir` and are still subject to the configured `includes` and
+`excludes`, so passing a file that the config skips processes nothing. Unlike a full run, passing a
+file explicitly processes it even if Git ignores it, the same way `git add --force` does. Paths that
+do not exist, which is what a diff of deleted files gives you, are skipped with a warning.
+
+Note that `attrs.git_file_created_year` still requires traversing the history down to the commit
+that added a file, so the speedup is the largest either when `git.attrs` is disabled, or when the
+files have been added recently.
+
+Whole-repository runs traverse the history on all the available cores, so `git.attrs` costs roughly
+what `git log` costs. Setting `git.attrs = 'disable'` remains the cheapest option if your header
+template does not use any of the `attrs.git_*` values.
+
 ### GitHub Actions
 
 The HawkEye GitHub Action enables users to run license header check by HawkEye with a config file.

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -23,6 +24,7 @@ use hawkeye_fmt::document::Document;
 use hawkeye_fmt::error::Error;
 use hawkeye_fmt::header::matcher::HeaderMatcher;
 use hawkeye_fmt::processor::check_license_header;
+use hawkeye_fmt::processor::check_license_header_of_paths;
 use hawkeye_fmt::processor::Callback;
 use serde::Serialize;
 
@@ -48,6 +50,62 @@ struct SharedOptions {
     output_file: Option<PathBuf>,
     #[arg(long, help = "fail if process unknown files", default_value_t = false)]
     fail_if_unknown: bool,
+    #[arg(
+        value_name = "PATH",
+        help = "Process only these files and directories, instead of the whole baseDir"
+    )]
+    paths: Vec<PathBuf>,
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Read the paths to process from FILE, one per line ('-' for stdin)"
+    )]
+    files_from: Option<PathBuf>,
+}
+
+impl SharedOptions {
+    /// The paths to process, or `None` to process the whole `baseDir`.
+    fn selected_paths(&self) -> Option<Vec<PathBuf>> {
+        if self.paths.is_empty() && self.files_from.is_none() {
+            return None;
+        }
+
+        let mut paths = self.paths.clone();
+        if let Some(file) = self.files_from.as_ref() {
+            paths.extend(read_paths_from(file));
+        }
+        Some(paths)
+    }
+
+    fn process<C: Callback>(&self, config: PathBuf, context: &mut C) {
+        let result = match self.selected_paths() {
+            None => check_license_header(config, context),
+            Some(paths) => check_license_header_of_paths(config, &paths, context),
+        };
+        result.unwrap();
+    }
+}
+
+fn read_paths_from(file: &Path) -> Vec<PathBuf> {
+    fn do_read_paths_from(file: &Path) -> std::io::Result<String> {
+        if file == Path::new("-") {
+            let mut content = String::new();
+            std::io::stdin().read_to_string(&mut content)?;
+            return Ok(content);
+        }
+        std::fs::read_to_string(file)
+    }
+
+    let content = do_read_paths_from(file)
+        .unwrap_or_else(|err| panic!("failed to read paths from file {}: {}", file.display(), err));
+
+    // tolerate the NUL separated output of git commands, like `git diff -z --name-only`
+    content
+        .split(['\n', '\0'])
+        .map(|line| line.trim_end_matches('\r'))
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect()
 }
 
 #[derive(Args)]
@@ -108,13 +166,13 @@ impl Callback for CheckContext {
 }
 
 impl CommandCheck {
-    fn run(self) {
-        let config = self.shared.config.unwrap_or_else(default_config);
+    fn run(mut self) {
+        let config = self.shared.config.take().unwrap_or_else(default_config);
         let mut context = CheckContext {
             unknown: vec![],
             missing: vec![],
         };
-        check_license_header(config, &mut context).unwrap();
+        self.shared.process(config, &mut context);
 
         let mut failed = check_unknown_files(&context.unknown, self.shared.fail_if_unknown);
         if !context.missing.is_empty() {
@@ -179,14 +237,14 @@ impl Callback for FormatContext {
 }
 
 impl CommandFormat {
-    fn run(self) {
-        let config = self.shared.config.unwrap_or_else(default_config);
+    fn run(mut self) {
+        let config = self.shared.config.take().unwrap_or_else(default_config);
         let mut context = FormatContext {
             dry_run: self.shared_edit.dry_run,
             unknown: vec![],
             updated: vec![],
         };
-        check_license_header(config, &mut context).unwrap();
+        self.shared.process(config, &mut context);
 
         let mut failed = check_unknown_files(&context.unknown, self.shared.fail_if_unknown);
         if !context.updated.is_empty() {
@@ -256,14 +314,14 @@ impl Callback for RemoveContext {
 }
 
 impl CommandRemove {
-    fn run(self) {
-        let config = self.shared.config.unwrap_or_else(default_config);
+    fn run(mut self) {
+        let config = self.shared.config.take().unwrap_or_else(default_config);
         let mut context = RemoveContext {
             dry_run: self.shared_edit.dry_run,
             unknown: vec![],
             removed: vec![],
         };
-        check_license_header(config, &mut context).unwrap();
+        self.shared.process(config, &mut context);
 
         let mut failed = check_unknown_files(&context.unknown, self.shared.fail_if_unknown);
         if !context.removed.is_empty() {

--- a/fmt/src/git.rs
+++ b/fmt/src/git.rs
@@ -15,6 +15,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -101,21 +102,44 @@ pub struct GitFileAttrs {
 pub fn resolve_file_attrs(
     git_context: GitContext,
 ) -> Result<HashMap<PathBuf, GitFileAttrs>, Error> {
-    let mut attrs = HashMap::new();
+    resolve_file_attrs_of(git_context, None)
+}
 
+/// Resolve the Git attributes of the files of interest, given as absolute paths.
+///
+/// Passing `None` resolves the attributes of every file in the repository, which requires walking
+/// the whole history of the repository.
+///
+/// Otherwise, only the attributes of the given files are resolved, and the traversal stops as soon
+/// as the commits that added them are found. Note that a file which has been deleted and added
+/// again may then report the most recent addition as its creation, like a renamed file does.
+pub fn resolve_file_attrs_of(
+    git_context: GitContext,
+    interests: Option<&HashSet<PathBuf>>,
+) -> Result<HashMap<PathBuf, GitFileAttrs>, Error> {
     if git_context.config.attrs.is_disable() {
-        return Ok(attrs);
+        return Ok(HashMap::new());
     }
 
-    let repo = match git_context.repo {
+    let mut repo = match git_context.repo {
         Some(repo) => repo,
-        None => return Ok(attrs),
+        None => return Ok(HashMap::new()),
     };
 
     let current_username = match repo.committer() {
         Some(Ok(username)) => username.name.to_string(),
         _ => "<unknown>".to_string(),
     };
+
+    let make_error = || Error::new("cannot resolve git file attributes");
+
+    // Traversing the history diffs one commit against another over and over, so most of the trees
+    // are decoded again and again. Cache them, or the object database dominates the runtime.
+    let object_cache_size = {
+        let index = repo.index_or_empty().or_raise(make_error)?;
+        repo.compute_object_cache_size_for_tree_diffs(&index)
+    };
+    repo.object_cache_size_if_unset(object_cache_size);
 
     let worktree = repo.worktree().expect("worktree cannot be absent");
     let workdir = repo.workdir().expect("workdir cannot be absent");
@@ -130,77 +154,78 @@ pub fn resolve_file_attrs(
         .excludes(None)
         .or_raise(|| Error::new("cannot create gix exclude stack"))?;
 
-    let mut update_attrs = |rela_path: &Path, time: gix::date::Time, author: &str| {
-        let filepath = workdir.join(rela_path);
-        match attrs.entry(filepath) {
-            Entry::Occupied(mut ent) => {
-                let attrs: &mut GitFileAttrs = ent.get_mut();
-                attrs.created_time = time.min(attrs.created_time);
-                attrs.modified_time = time.max(attrs.modified_time);
-                attrs.authors.insert(author.to_string());
-            }
-            Entry::Vacant(ent) => {
-                ent.insert(GitFileAttrs {
-                    created_time: time,
-                    modified_time: time,
-                    authors: {
-                        let mut authors = BTreeSet::new();
-                        authors.insert(author.to_string());
-                        authors
-                    },
-                });
-            }
-        }
-    };
-
-    let mut process_changes = |changes: Vec<Change>, time: gix::date::Time, author: &str| {
-        for change in changes {
-            match change {
-                Change::Addition { location, .. } | Change::Modification { location, .. } => {
-                    update_attrs(&gix::path::from_bstring(location), time, author);
-                }
-                Change::Deletion { .. } => continue, // skip deletion
-                Change::Rewrite { .. } => unreachable!("rewrite has been disabled"),
-            }
-        }
-    };
-
-    let option = {
-        let mut option = gix::diff::Options::default();
-        option.track_path();
-        option
-    };
-
-    let make_error = || Error::new("cannot resolve git file attributes");
-
     let head = repo.head_commit().or_raise(make_error)?;
-    let mut next_commit = head.clone();
 
-    for info in head.ancestors().all().or_raise(make_error)? {
-        let info = info.or_raise(make_error)?;
-        let this_commit = info.object().or_raise(make_error)?;
-        let time = next_commit.time().or_raise(make_error)?;
-        let author = next_commit.author().or_raise(make_error)?.name.to_string();
-
-        let this_tree = this_commit.tree().or_raise(make_error)?;
-        let next_tree = next_commit.tree().or_raise(make_error)?;
-
-        let changes = repo
-            .diff_tree_to_tree(Some(&this_tree), Some(&next_tree), Some(option))
-            .or_raise(make_error)?;
-        process_changes(changes, time, &author);
-
-        next_commit = this_commit;
+    // Files of interest whose creation is yet to be found in the history. Files that are not part
+    // of HEAD, be they untracked or freshly added, are not in it; they are resolved as committed
+    // now while processing the dirty working tree.
+    let mut pending = HashSet::new();
+    if let Some(interests) = interests {
+        let head_tree = head.tree().or_raise(make_error)?;
+        for filepath in interests {
+            let Ok(rela_path) = filepath.strip_prefix(&workdir) else {
+                continue;
+            };
+            if head_tree
+                .lookup_entry_by_path(rela_path)
+                .or_raise(make_error)?
+                .is_some()
+            {
+                pending.insert(filepath.clone());
+            }
+        }
     }
 
-    // process the root commit
-    let time = next_commit.time().or_raise(make_error)?;
-    let author = next_commit.author().or_raise(make_error)?.name.to_string();
-    let next_tree = next_commit.tree().or_raise(make_error)?;
-    let changes = repo
-        .diff_tree_to_tree(None, Some(&next_tree), Some(option))
-        .or_raise(make_error)?;
-    process_changes(changes, time, &author);
+    let mut attrs = if interests.is_some() {
+        let mut attrs = HashMap::new();
+        let mut additions = vec![];
+        let mut ancestors = head.ancestors().all().or_raise(make_error)?;
+
+        // Walk commit by commit for a while: the files of interest may have been added recently,
+        // in which case the traversal is over after a handful of commits.
+        let mut walked = 0;
+        while !pending.is_empty() && walked < SEQUENTIAL_COMMITS {
+            let Some(info) = ancestors.next() else { break };
+            let info = info.or_raise(make_error)?;
+            resolve_commit_attrs(
+                &repo,
+                &workdir,
+                interests,
+                &info.id,
+                &mut attrs,
+                &mut additions,
+            )?;
+            for filepath in additions.iter() {
+                pending.remove(filepath);
+            }
+            walked += 1;
+        }
+
+        if pending.is_empty() {
+            log::debug!("stop traversing history since all files of interest are resolved");
+        } else {
+            // Walking commit by commit is not paying off, so hand the rest to the threads.
+            let mut commits = vec![];
+            for info in ancestors {
+                commits.push(info.or_raise(make_error)?.id);
+            }
+            let rest =
+                resolve_commits_attrs(&repo, &workdir, interests, object_cache_size, &commits)?;
+            merge_file_attrs(&mut attrs, rest);
+        }
+
+        attrs
+    } else {
+        resolve_history_attrs(&repo, &workdir, object_cache_size, head)?
+    };
+
+    let mut update_attrs = |rela_path: &Path, time: gix::date::Time, author: &str| {
+        let filepath = workdir.join(rela_path);
+        if interests.is_some_and(|interests| !interests.contains(&filepath)) {
+            return;
+        }
+        update_file_attrs(&mut attrs, filepath, time, author);
+    };
 
     // process dirty working tree
     let index = repo.index_or_empty().or_raise(make_error)?;
@@ -217,6 +242,14 @@ pub fn resolve_file_attrs(
                 gix::status::index_worktree::Item::DirectoryContents { entry, .. } => {
                     if entry.disk_kind.is_some_and(|k| k.is_dir()) {
                         let dirpath = workdir.join(gix::path::from_bstr(&entry.rela_path));
+                        if interests.is_some_and(|interests| {
+                            !interests
+                                .iter()
+                                .any(|filepath| filepath.starts_with(&dirpath))
+                        }) {
+                            log::debug!(dirpath:?; "skip untracked directory without file of interest");
+                            continue;
+                        }
                         let mut it = WalkDir::new(dirpath).follow_links(false).into_iter();
                         while let Some(entry) = it.next() {
                             let entry =
@@ -285,4 +318,235 @@ pub fn resolve_file_attrs(
     }
 
     Ok(attrs)
+}
+
+/// The smallest number of commits worth handing over to a thread of its own.
+const COMMITS_PER_THREAD: usize = 512;
+
+/// How many commits to walk one by one before giving up on resolving the files of interest early.
+const SEQUENTIAL_COMMITS: usize = 512;
+
+/// Resolve the attributes of every file in the history reachable from `head`.
+fn resolve_history_attrs(
+    repo: &Repository,
+    workdir: &Path,
+    object_cache_size: usize,
+    head: gix::Commit<'_>,
+) -> Result<HashMap<PathBuf, GitFileAttrs>, Error> {
+    let make_error = || Error::new("cannot resolve git file attributes");
+
+    let mut commits = vec![];
+    for info in head.ancestors().all().or_raise(make_error)? {
+        commits.push(info.or_raise(make_error)?.id);
+    }
+
+    resolve_commits_attrs(repo, workdir, None, object_cache_size, &commits)
+}
+
+/// Fold the changes of the given commits into one set of attributes.
+///
+/// Commits are diffed against their own parent, so they can be spread over as many threads as the
+/// machine affords, each of them folding its share of the history into attributes of its own.
+fn resolve_commits_attrs(
+    repo: &Repository,
+    workdir: &Path,
+    interests: Option<&HashSet<PathBuf>>,
+    object_cache_size: usize,
+    commits: &[gix::ObjectId],
+) -> Result<HashMap<PathBuf, GitFileAttrs>, Error> {
+    let threads = std::thread::available_parallelism()
+        .map(|threads| threads.get())
+        .unwrap_or(1)
+        .min(commits.len().div_ceil(COMMITS_PER_THREAD))
+        .max(1);
+    log::debug!(
+        "traversing {} commits with {threads} thread(s)",
+        commits.len()
+    );
+
+    if threads == 1 {
+        let mut attrs = HashMap::new();
+        let mut additions = vec![];
+        for id in commits.iter() {
+            resolve_commit_attrs(repo, workdir, interests, id, &mut attrs, &mut additions)?;
+        }
+        return Ok(attrs);
+    }
+
+    // Each thread caches the objects of its own share of the history. Handing out contiguous
+    // chunks keeps those caches warm, as neighbouring commits share most of their trees.
+    let thread_cache_size = (object_cache_size / threads).max(4 * 1024 * 1024);
+    let repo = repo.clone().into_sync();
+    let chunk_size = commits.len().div_ceil(threads);
+
+    let mut attrs = HashMap::new();
+    let results = std::thread::scope(|scope| {
+        let handles = commits
+            .chunks(chunk_size)
+            .map(|chunk| {
+                let repo = &repo;
+                scope.spawn(move || -> Result<HashMap<PathBuf, GitFileAttrs>, Error> {
+                    let mut repo = repo.to_thread_local();
+                    repo.object_cache_size_if_unset(thread_cache_size);
+
+                    let mut attrs = HashMap::new();
+                    let mut additions = vec![];
+                    for id in chunk.iter() {
+                        resolve_commit_attrs(
+                            &repo,
+                            workdir,
+                            interests,
+                            id,
+                            &mut attrs,
+                            &mut additions,
+                        )?;
+                    }
+                    Ok(attrs)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join())
+            .collect::<Vec<_>>()
+    });
+
+    for result in results {
+        match result {
+            Ok(result) => merge_file_attrs(&mut attrs, result?),
+            Err(_) => bail!(Error::new("a thread traversing the history panicked")),
+        }
+    }
+
+    Ok(attrs)
+}
+
+/// Fold the changes a commit brings into `attrs`, and report the files it adds in `additions`.
+///
+/// Merge commits are skipped, as `git log` does by default: whatever they merge is attributed to
+/// the commits of the merged branches.
+fn resolve_commit_attrs(
+    repo: &Repository,
+    workdir: &Path,
+    interests: Option<&HashSet<PathBuf>>,
+    id: &gix::oid,
+    attrs: &mut HashMap<PathBuf, GitFileAttrs>,
+    additions: &mut Vec<PathBuf>,
+) -> Result<(), Error> {
+    let make_error = || Error::new("cannot resolve git file attributes");
+
+    additions.clear();
+
+    let commit = repo.find_commit(id).or_raise(make_error)?;
+    let mut parents = commit.parent_ids();
+    let parent = parents.next();
+    if parents.next().is_some() {
+        return Ok(());
+    }
+
+    // Diffing a commit against its own parent keeps the diff minimal, since the two trees share
+    // every subtree that the commit does not touch.
+    let parent_tree = match parent {
+        Some(parent) => {
+            let parent = repo.find_commit(parent).or_raise(make_error)?;
+            Some(parent.tree().or_raise(make_error)?)
+        }
+        None => None, // the root commit adds all the files it holds
+    };
+    let this_tree = commit.tree().or_raise(make_error)?;
+
+    let option = {
+        let mut option = gix::diff::Options::default();
+        option.track_path();
+        option
+    };
+    let changes = repo
+        .diff_tree_to_tree(parent_tree.as_ref(), Some(&this_tree), Some(option))
+        .or_raise(make_error)?;
+    if changes.is_empty() {
+        return Ok(());
+    }
+
+    let time = commit.time().or_raise(make_error)?;
+    let author = commit.author().or_raise(make_error)?.name.to_string();
+
+    for change in changes {
+        let (location, entry_mode, added) = match change {
+            Change::Addition {
+                location,
+                entry_mode,
+                ..
+            } => (location, entry_mode, true),
+            Change::Modification {
+                location,
+                entry_mode,
+                ..
+            } => (location, entry_mode, false),
+            Change::Deletion { .. } => continue, // skip deletion
+            Change::Rewrite { .. } => unreachable!("rewrite has been disabled"),
+        };
+
+        // only files ever carry a license header; keeping directories would bloat the attributes
+        if !entry_mode.is_blob_or_symlink() {
+            continue;
+        }
+
+        let filepath = workdir.join(gix::path::from_bstring(location));
+        if interests.is_some_and(|interests| !interests.contains(&filepath)) {
+            continue;
+        }
+        if added {
+            additions.push(filepath.clone());
+        }
+        update_file_attrs(attrs, filepath, time, &author);
+    }
+
+    Ok(())
+}
+
+fn update_file_attrs(
+    attrs: &mut HashMap<PathBuf, GitFileAttrs>,
+    filepath: PathBuf,
+    time: gix::date::Time,
+    author: &str,
+) {
+    match attrs.entry(filepath) {
+        Entry::Occupied(mut ent) => {
+            let attrs: &mut GitFileAttrs = ent.get_mut();
+            attrs.created_time = time.min(attrs.created_time);
+            attrs.modified_time = time.max(attrs.modified_time);
+            attrs.authors.insert(author.to_string());
+        }
+        Entry::Vacant(ent) => {
+            ent.insert(GitFileAttrs {
+                created_time: time,
+                modified_time: time,
+                authors: {
+                    let mut authors = BTreeSet::new();
+                    authors.insert(author.to_string());
+                    authors
+                },
+            });
+        }
+    }
+}
+
+fn merge_file_attrs(
+    attrs: &mut HashMap<PathBuf, GitFileAttrs>,
+    other: HashMap<PathBuf, GitFileAttrs>,
+) {
+    for (filepath, other) in other {
+        match attrs.entry(filepath) {
+            Entry::Occupied(mut ent) => {
+                let attrs: &mut GitFileAttrs = ent.get_mut();
+                attrs.created_time = other.created_time.min(attrs.created_time);
+                attrs.modified_time = other.modified_time.max(attrs.modified_time);
+                attrs.authors.extend(other.authors);
+            }
+            Entry::Vacant(ent) => {
+                ent.insert(other);
+            }
+        }
+    }
 }

--- a/fmt/src/processor.rs
+++ b/fmt/src/processor.rs
@@ -60,10 +60,10 @@ pub fn check_license_header<C: Callback>(
 
 /// Check the license headers of the given files and directories only.
 ///
-/// Paths are resolved against the `baseDir` of the config, and they are still subject to its
-/// includes and excludes. This skips walking the whole `baseDir`, as well as the parts of the Git
-/// history that are irrelevant to these paths, which is significantly faster on large
-/// repositories. An empty `paths` selects no file at all.
+/// Paths are resolved against the current directory, and they are still subject to the includes
+/// and excludes of the config; those outside of its `baseDir` are skipped. This skips walking the
+/// whole `baseDir`, as well as the parts of the Git history that are irrelevant to these paths,
+/// which is significantly faster on large repositories. An empty `paths` selects no file at all.
 pub fn check_license_header_of_paths<C: Callback>(
     run_config: PathBuf,
     paths: &[PathBuf],

--- a/fmt/src/processor.rs
+++ b/fmt/src/processor.rs
@@ -50,8 +50,31 @@ pub trait Callback {
     fn on_not_matched(&mut self, header: &HeaderMatcher, document: Document) -> Result<(), Error>;
 }
 
+/// Check the license headers of all the files selected by the config.
 pub fn check_license_header<C: Callback>(
     run_config: PathBuf,
+    callback: &mut C,
+) -> Result<(), Error> {
+    do_check_license_header(run_config, None, callback)
+}
+
+/// Check the license headers of the given files and directories only.
+///
+/// Paths are resolved against the `baseDir` of the config, and they are still subject to its
+/// includes and excludes. This skips walking the whole `baseDir`, as well as the parts of the Git
+/// history that are irrelevant to these paths, which is significantly faster on large
+/// repositories. An empty `paths` selects no file at all.
+pub fn check_license_header_of_paths<C: Callback>(
+    run_config: PathBuf,
+    paths: &[PathBuf],
+    callback: &mut C,
+) -> Result<(), Error> {
+    do_check_license_header(run_config, Some(paths), callback)
+}
+
+fn do_check_license_header<C: Callback>(
+    run_config: PathBuf,
+    paths: Option<&[PathBuf]>,
     callback: &mut C,
 ) -> Result<(), Error> {
     let config = {
@@ -86,8 +109,16 @@ pub fn check_license_header<C: Callback>(
             config.use_default_excludes,
             git_context.clone(),
         );
-        selection.select()?
+        match paths {
+            None => selection.select()?,
+            Some(paths) => selection.select_paths(paths)?,
+        }
     };
+
+    if paths.is_some() && selected_files.is_empty() {
+        log::info!("no file is selected to process");
+        return Ok(());
+    }
 
     let mapping = {
         let mut mapping = config.mapping.clone();
@@ -141,7 +172,13 @@ pub fn check_license_header<C: Callback>(
         HeaderMatcher::new(header_source.content)
     };
 
-    let git_file_attrs = git::resolve_file_attrs(git_context)?;
+    let git_file_attrs = match paths {
+        None => git::resolve_file_attrs(git_context)?,
+        Some(_) => {
+            let interests = selected_files.iter().cloned().collect();
+            git::resolve_file_attrs_of(git_context, Some(&interests))?
+        }
+    };
 
     let document_factory = DocumentFactory::new(
         mapping,

--- a/fmt/src/selection.rs
+++ b/fmt/src/selection.rs
@@ -70,7 +70,8 @@ impl Selection {
         self.do_select(None)
     }
 
-    /// Select only the given files and directories, which are resolved against the base directory.
+    /// Select only the given files and directories, which are resolved against the current
+    /// directory.
     ///
     /// This is meant for large repositories, where walking the whole base directory (and its Git
     /// history) is way more expensive than processing the files one is interested in.
@@ -192,12 +193,8 @@ fn resolve_paths(
     let mut dirs = vec![];
     let mut files = vec![];
     for path in paths {
-        let path = if path.is_absolute() {
-            path.clone()
-        } else {
-            basedir.join(path)
-        };
-
+        // resolved like any other path on the command line, that is, relative to the current
+        // directory, which is what the likes of `git diff --name-only` and pre-commit hand over
         let absolute_path = match path.canonicalize() {
             Ok(absolute_path) => absolute_path,
             Err(err) => {

--- a/fmt/src/selection.rs
+++ b/fmt/src/selection.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use exn::ensure;
 use exn::Result;
 use exn::ResultExt;
+use ignore::overrides::Override;
 use ignore::overrides::OverrideBuilder;
 use walkdir::WalkDir;
 
@@ -64,12 +65,31 @@ impl Selection {
         }
     }
 
+    /// Select all the files under the base directory.
     pub fn select(self) -> Result<Vec<PathBuf>, Error> {
+        self.do_select(None)
+    }
+
+    /// Select only the given files and directories, which are resolved against the base directory.
+    ///
+    /// This is meant for large repositories, where walking the whole base directory (and its Git
+    /// history) is way more expensive than processing the files one is interested in.
+    ///
+    /// Directories are walked as [`Selection::select`] does. Files are selected as long as they
+    /// match `includes` and `excludes`; listing a file explicitly overrides the Git ignore rules,
+    /// like `git add --force` does. Paths that do not exist, or that are outside the base
+    /// directory, are skipped with a warning.
+    pub fn select_paths(self, paths: &[PathBuf]) -> Result<Vec<PathBuf>, Error> {
+        self.do_select(Some(paths))
+    }
+
+    fn do_select(self, paths: Option<&[PathBuf]>) -> Result<Vec<PathBuf>, Error> {
         log::debug!(
-            "selecting files with baseDir: {}, included: {:?}, excluded: {:?}",
+            "selecting files with baseDir: {}, included: {:?}, excluded: {:?}, paths: {:?}",
             self.basedir.display(),
             self.includes,
             self.excludes,
+            paths,
         );
 
         let (excludes, reverse_excludes) = {
@@ -95,30 +115,178 @@ impl Selection {
             ))
         );
 
-        let ignore = self.git_context.config.ignore.is_auto();
-        let result = match self.git_context.repo {
-            None => select_files_with_ignore(
-                &self.basedir,
-                &includes,
-                &excludes,
-                &reverse_excludes,
-                ignore,
-            )?,
-            Some(repo) => {
-                select_files_with_git(&self.basedir, &includes, &excludes, &reverse_excludes, repo)?
-            }
+        let matcher = build_matcher(&self.basedir, &includes, &excludes, &reverse_excludes)?;
+        let (dirs, files) = match paths {
+            None => (vec![self.basedir.clone()], vec![]),
+            Some(paths) => resolve_paths(&self.basedir, paths)?,
         };
+
+        let ignore = self.git_context.config.ignore.is_auto();
+        let mut result = vec![];
+        match self.git_context.repo {
+            None => {
+                for dir in &dirs {
+                    result.extend(select_files_with_ignore(dir, &matcher, ignore)?);
+                }
+                for file in &files {
+                    // the ignore crate matches paths relative to the base directory
+                    if is_selected_file(&matcher, &file.rela_path) {
+                        result.push(file.path.clone());
+                    }
+                }
+            }
+            Some(repo) => {
+                for dir in &dirs {
+                    result.extend(select_files_with_git(dir, &matcher, &repo)?);
+                }
+                if !files.is_empty() {
+                    let workdir = repo.workdir().expect("workdir cannot be absent");
+                    let workdir = canonicalize(workdir)?;
+                    for file in &files {
+                        // the git helper matches paths relative to the workdir
+                        let rela_path = match file.path.strip_prefix(&workdir) {
+                            Ok(rela_path) => rela_path,
+                            Err(_) => {
+                                log::warn!(
+                                    "skip file outside of the git repository: {}",
+                                    file.path.display()
+                                );
+                                continue;
+                            }
+                        };
+                        if is_selected_file(&matcher, rela_path) {
+                            result.push(file.path.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if paths.is_some() {
+            // a file can be selected both on its own and as part of a selected directory
+            result.sort();
+            result.dedup();
+        }
 
         log::debug!("selected files: {:?} (count: {})", result, result.len());
         Ok(result)
     }
 }
 
-fn select_files_with_ignore(
-    basedir: &PathBuf,
+/// A file that has been explicitly passed for processing.
+struct FileToSelect {
+    /// Path relative to the base directory, that is, what includes and excludes are anchored to.
+    rela_path: PathBuf,
+    /// Absolute path, as the directory walkers report the files they select.
+    path: PathBuf,
+}
+
+/// Resolve the given paths against the base directory, and split them into directories to walk and
+/// files to select. Paths that cannot be resolved, or that escape the base directory, are dropped.
+fn resolve_paths(
+    basedir: &Path,
+    paths: &[PathBuf],
+) -> Result<(Vec<PathBuf>, Vec<FileToSelect>), Error> {
+    let absolute_basedir = canonicalize(basedir)?;
+
+    let mut dirs = vec![];
+    let mut files = vec![];
+    for path in paths {
+        let path = if path.is_absolute() {
+            path.clone()
+        } else {
+            basedir.join(path)
+        };
+
+        let absolute_path = match path.canonicalize() {
+            Ok(absolute_path) => absolute_path,
+            Err(err) => {
+                log::warn!(err:?; "skip path that cannot be resolved: {}", path.display());
+                continue;
+            }
+        };
+
+        let rela_path = match absolute_path.strip_prefix(&absolute_basedir) {
+            Ok(rela_path) => rela_path.to_path_buf(),
+            Err(_) => {
+                log::warn!(
+                    "skip path outside of baseDir {}: {}",
+                    basedir.display(),
+                    path.display()
+                );
+                continue;
+            }
+        };
+
+        if absolute_path.is_dir() {
+            // walk directories with the absolute path, as the git helper does
+            dirs.push(absolute_path);
+        } else if absolute_path.is_file() {
+            files.push(FileToSelect {
+                rela_path,
+                path: absolute_path,
+            });
+        } else {
+            log::warn!(
+                "skip path that is neither a file nor a directory: {}",
+                path.display()
+            );
+        }
+    }
+
+    Ok((dirs, files))
+}
+
+/// Whether an explicitly passed file matches the configured includes and excludes.
+fn is_selected_file(matcher: &Override, rela_path: &Path) -> bool {
+    for dir in rela_path.ancestors().skip(1) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        if matcher.matched(dir, true).is_ignore() {
+            log::debug!(rela_path:?, dir:?; "skip glob ignored file under ignored directory");
+            return false;
+        }
+    }
+
+    if !matcher.matched(rela_path, false).is_whitelist() {
+        log::debug!(rela_path:?; "skip glob ignored file");
+        return false;
+    }
+
+    true
+}
+
+fn build_matcher(
+    basedir: &Path,
     includes: &[String],
     excludes: &[String],
     reverse_excludes: &[String],
+) -> Result<Override, Error> {
+    let make_error = || Error::new("failed to build the include and exclude matcher");
+
+    let mut builder = OverrideBuilder::new(basedir);
+    for pat in includes.iter() {
+        builder.add(pat).or_raise(make_error)?;
+    }
+    for pat in excludes.iter() {
+        let pat = format!("!{pat}");
+        builder.add(pat.as_str()).or_raise(make_error)?;
+    }
+    for pat in reverse_excludes.iter() {
+        builder.add(pat).or_raise(make_error)?;
+    }
+    builder.build().or_raise(make_error)
+}
+
+fn canonicalize(path: &Path) -> Result<PathBuf, Error> {
+    path.canonicalize()
+        .or_raise(|| Error::new(format!("cannot resolve absolute path: {}", path.display())))
+}
+
+fn select_files_with_ignore(
+    root: &Path,
+    matcher: &Override,
     turn_on_git_ignore: bool,
 ) -> Result<Vec<PathBuf>, Error> {
     let make_error = || Error::new("failed to select files with ignore crate");
@@ -126,7 +294,7 @@ fn select_files_with_ignore(
     log::debug!(turn_on_git_ignore; "Selecting files with ignore crate");
     let mut result = vec![];
 
-    let walker = ignore::WalkBuilder::new(basedir)
+    let walker = ignore::WalkBuilder::new(root)
         .ignore(false) // do not use .ignore file
         .hidden(false) // check hidden files
         .follow_links(true) // proper path name
@@ -134,20 +302,7 @@ fn select_files_with_ignore(
         .git_exclude(turn_on_git_ignore)
         .git_global(turn_on_git_ignore)
         .git_ignore(turn_on_git_ignore)
-        .overrides({
-            let mut builder = OverrideBuilder::new(basedir);
-            for pat in includes.iter() {
-                builder.add(pat).or_raise(make_error)?;
-            }
-            for pat in excludes.iter() {
-                let pat = format!("!{pat}");
-                builder.add(pat.as_str()).or_raise(make_error)?;
-            }
-            for pat in reverse_excludes.iter() {
-                builder.add(pat).or_raise(make_error)?;
-            }
-            builder.build().or_raise(make_error)?
-        })
+        .overrides(matcher.clone())
         .build();
 
     for mat in walker {
@@ -161,49 +316,18 @@ fn select_files_with_ignore(
 }
 
 fn select_files_with_git(
-    basedir: &Path,
-    includes: &[String],
-    excludes: &[String],
-    reverse_excludes: &[String],
-    repo: gix::Repository,
+    root: &Path,
+    matcher: &Override,
+    repo: &gix::Repository,
 ) -> Result<Vec<PathBuf>, Error> {
     log::debug!("selecting files with git helper");
     let mut result = vec![];
 
-    let matcher = {
-        let make_error = || Error::new("failed to select files with ignore crate");
-
-        let mut builder = OverrideBuilder::new(basedir);
-        for pat in includes.iter() {
-            builder.add(pat).or_raise(make_error)?;
-        }
-        for pat in excludes.iter() {
-            let pat = format!("!{pat}");
-            builder.add(pat.as_str()).or_raise(make_error)?;
-        }
-        for pat in reverse_excludes.iter() {
-            builder.add(pat).or_raise(make_error)?;
-        }
-        builder.build().or_raise(make_error)?
-    };
-
-    let basedir = basedir.canonicalize().or_raise(|| {
-        Error::new(format!(
-            "cannot resolve absolute path: {}",
-            basedir.display()
-        ))
-    })?;
-    let mut it = WalkDir::new(basedir.clone())
-        .follow_links(false)
-        .into_iter();
+    let root = canonicalize(root)?;
+    let mut it = WalkDir::new(root).follow_links(false).into_iter();
 
     let workdir = repo.workdir().expect("workdir cannot be absent");
-    let workdir = workdir.canonicalize().or_raise(|| {
-        Error::new(format!(
-            "cannot resolve absolute path: {}",
-            workdir.display()
-        ))
-    })?;
+    let workdir = canonicalize(workdir)?;
     let worktree = repo.worktree().expect("worktree cannot be absent");
     let mut excludes = worktree
         .excludes(None)

--- a/tests/it.py
+++ b/tests/it.py
@@ -37,7 +37,7 @@ rootdir = basedir.parent
 subprocess.run(["cargo", "build", "--bin", "hawkeye"], cwd=rootdir, check=True)
 hawkeye = rootdir / "target" / "debug" / "hawkeye"
 
-def drive(name, files, create_temp_copy=False):
+def drive(name, files, create_temp_copy=False, extra_args=None, untouched=None):
     temp_paths = []
     expected_files = []
     case_dir = basedir / name
@@ -60,10 +60,15 @@ def drive(name, files, create_temp_copy=False):
         else:
             temp_paths = files
             expected_files = [f"{file}.expected" for file in files]
-        subprocess.run([hawkeye, "format", "--fail-if-unknown", "--fail-if-updated=false", "--dry-run"], cwd=case_dir, check=True)
+        command = [hawkeye, "format", "--fail-if-unknown", "--fail-if-updated=false", "--dry-run"]
+        subprocess.run(command + (extra_args or []), cwd=case_dir, check=True)
 
         for file in temp_paths:
             diff_files(case_dir / f"{file}.expected", case_dir / f"{file}.formatted")
+        for file in untouched or []:
+            if os.path.exists(case_dir / f"{file}.formatted"):
+                print(f"{file} should not have been processed")
+                exit(1)
     finally:
         # Remove all temp files at the end
         if create_temp_copy:
@@ -80,3 +85,5 @@ drive("bom_issue", ["headless_bom.cs"])
 drive("regression_blank_line", ["main.rs"])
 drive("regression_no_blank_lines", ["repro.py"])
 drive("disk_file_created_year", ["main.rs"], True)
+drive("select_paths", ["selected.rs"], extra_args=["selected.rs"], untouched=["not_selected.rs"])
+drive("select_paths", ["selected.rs"], extra_args=["--files-from", "files.txt"], untouched=["not_selected.rs"])

--- a/tests/select_paths/files.txt
+++ b/tests/select_paths/files.txt
@@ -1,0 +1,1 @@
+selected.rs

--- a/tests/select_paths/license.txt
+++ b/tests/select_paths/license.txt
@@ -1,0 +1,11 @@
+Copyright {{props["inceptionYear"]}} {{props["copyrightOwner"]}}
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/select_paths/licenserc.toml
+++ b/tests/select_paths/licenserc.toml
@@ -1,0 +1,8 @@
+baseDir = "."
+headerPath = "license.txt"
+
+excludes = ["licenserc.toml", "*.expected"]
+
+[properties]
+inceptionYear = 2024
+copyrightOwner = "Mike Delaney <dev@mldelaney.io>"

--- a/tests/select_paths/not_selected.rs
+++ b/tests/select_paths/not_selected.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/select_paths/selected.rs
+++ b/tests/select_paths/selected.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/select_paths/selected.rs.expected
+++ b/tests/select_paths/selected.rs.expected
@@ -1,0 +1,15 @@
+// Copyright 2024 Mike Delaney <dev@mldelaney.io>
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Runs on large repositories spend nearly all their time in two places: walking the whole `baseDir`, and traversing the whole Git history to resolve `git.attrs`. This makes both cheaper, and fixes a misattribution bug in the traversal along the way.

## Process only the files you care about

`check`, `format`, and `remove` now take the files and directories to process:

```shell
hawkeye check src/main.rs src/lib.rs      # files
hawkeye check src                          # directories are walked as usual
git diff --name-only origin/main | hawkeye check --files-from -
```

Paths resolve against the current directory, like any other path on the command line, and still obey `includes`/`excludes`, so `hawkeye format Cargo.lock` processes nothing. Paths outside of the `baseDir` are skipped. A file passed explicitly is processed even if Git ignores it, like `git add --force` does. Paths that do not exist, which is what a diff of deleted files gives you, are skipped with a warning, as are paths outside the `baseDir`. An empty list processes nothing rather than everything, so it is safe to drive from a `pre-commit` hook.

### The pre-commit hooks pass the staged files

`hawkeye-format` and `hawkeye-format-docker` now set `pass_filenames: true`, so a commit only pays for the files it touches instead of formatting the whole repository. Verified end to end with `pre-commit try-repo`: only the passed files are formatted, a commit that touches nothing hawkeye cares about exits 0, and a commit whose files needed a header exits 1 with pre-commit's usual "files were modified by this hook".

This is also why paths on the command line resolve against the current directory: pre-commit hands over paths relative to the repository root, so resolving them against the `baseDir` would silently skip every file in a repository whose `baseDir` is a subdirectory.

Only the history relevant to those files is traversed: it stops as soon as the commits that added them are found, and files that are not part of `HEAD` (untracked or freshly added) do not hold it back at all, since they are resolved as committed now anyway. As a consequence, a file that was deleted and added again may report the most recent addition as `attrs.git_file_created_year`, the same way a renamed file already did.

## A faster history traversal

Three changes to `resolve_file_attrs`:

* **Diff each commit against its own parent.** It used to be diffed against the previously visited commit, which is only its child in a linear history. Merge commits are now skipped, as `git log` does by default.
* **Cache the decoded objects**, sized with gix's `compute_object_cache_size_for_tree_diffs`. Neighbouring commits share almost all of their trees, so without a cache every tree is inflated over and over. This is the single largest win.
* **Spread whole-history runs over the available cores**, each thread folding a contiguous chunk of the history into attributes of its own. Contiguous chunks keep the per-thread caches warm, `available_parallelism` respects CI cgroup limits, and repositories under 512 commits stay single-threaded. A targeted run walks 512 commits looking for an early exit before handing the rest to the same engine, so it never ends up slower than a whole-repository run.

## Fixes #203

Diffing a commit against the previously visited one meant diffing unrelated trees whenever the traversal jumped between branches, and the resulting changes were attributed to an unrelated commit's date and author, which is exactly the bug reported in #203.

Running the reproduction from that issue, on 6.5.1 and on this branch:

```console
$ hawkeye check                                    # 6.5.1
ERROR Found header missing in files: [".../A.rs"]   # A.rs renders as "2025 - 2026"

$ hawkeye check                                    # this branch
INFO No missing header file has been found.        # A.rs renders as "2025 - 2025"
```

On the repository measured below, **99 of 4953 files (2%) rendered a wrong copyright year**. Of 12 sampled disagreements between the old and the new traversal, the new one matches `git log --full-history --no-merges` on 12 and the old one on 0.

> [!NOTE]
> #207 already fixes #203 the same way, by diffing each non-merge commit against its true parent. I arrived at the same conclusion while chasing the performance of the traversal, and only found that PR afterwards, so credit for the diagnosis and the fix belongs there. If you would rather land #207 first, I am happy to rebase this on top of it and keep only the caching and threading parts, and #207's `tests/git_year_with_merge` regression test is the one worth keeping either way.

## Numbers

`hawkeye check` over a private repository of 23.5k commits, 2.5k merges and 4953 files, with `git.attrs` enabled:

| | wall |
|---|---|
| before | 57.5s |
| diff against own parent, skip merges | 44.5s |
| + object cache | 8.6s |
| + all cores | **1.35s** |
| *`git log --no-merges --name-only`, for reference* | *1.13s* |
| *file work alone (`attrs = 'disable'`)* | *0.44s* |

Targeted runs on the same repository: 0.05s for a recently added file, 1.2s for the oldest surviving one (was 2.7s before the fallback). On a repository of 131k commits, 20k merges and 24k files, a whole-repository run takes 31.7s; the old traversal had not finished after 30 minutes.

## Verification

* `tests/select_paths` covers both the positional and the `--files-from` form, and asserts that the file which was not listed stays untouched.
* The parallel and the sequential traversal agree on every file of two repositories (4950 and 77 files).
* 25 randomly sampled files match `git log --full-history --no-merges` exactly.
* `tests/it.py`, `cargo test`, `cargo +nightly clippy -D warnings`, `cargo +nightly fmt --check`, and the 1.90.0 build all pass; `hawkeye check` on this repository is clean.
