### PR TITLE
docs: prepare v7 alpha migration

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -39,4 +39,4 @@ types:
   - chore
   - revert
 
-targetUrl: https://github.com/korandoru/hawkeye/blob/main/.github/semantic.yml
+targetUrl: https://github.com/fast/hawkeye/blob/main/.github/semantic.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,128 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+## [7.0.0-alpha.1] 2026-08-19
+
+### Breaking changes
+
+* Rebuilt HawkEye as one `hawkeye` crate that provides both the Rust library and command-line application; the `hawkeye-fmt` crate and its v6 APIs are not preserved.
+* Replaced the v6 camel-case config with a strict snake-case schema organized around `header`, `files`, `props`, `git`, `styles`, and ordered `rules`.
+* Removed v6 compatibility switches, default exclude lists, configurable detection regexes, and the repository-specific GitHub Action.
+* Changed edit commands to succeed after making changes by default. Use `check` in CI or pass `--fail-on-change` to `format` and `remove`.
+* Replaced command-specific JSON files with one report schema written to stdout by `--output-format json`; logs and errors are written to stderr.
+* Defined Git creation as the latest addition in the current exact-path lifetime. Delete-and-recreate and rename-to-a-new-path start new histories.
+
+### New features
+
+* Added a public `Config`, `Engine`, `Scope`, report, and pending-edit API.
+* Added safe header replacement with explicit conflict reporting, literal line and block styles, and distinct accepted-input and canonical-output styles.
+* Added positional file and directory selection for `check`, `format`, and `remove`, including staged-file support in pre-commit hooks.
+* Added in-process Git discovery and file attributes through `gix`, including merge-aware history traversal without requiring a `git` executable.
+* Added human and JSON reports, stable exit-code categories, debug logging, and deterministic preservation of common file preambles and line endings.
+* Added cargo-binstall archives, a distroless multi-architecture container image, and Python and Docker pre-commit hooks.
+
+See [MIGRATE.md](https://github.com/fast/hawkeye/blob/main/MIGRATE.md) for the v6-to-v7 procedure and semantic differences.
+
+## [6.5.1] 2026-02-14
+
+### Bug fixes
+
+* Properly resolve relative paths when populating Git attributes for untracked folders.
+
+## [6.5.0] 2026-02-09
+
+### Notable changes
+
+* Minimal Supported Rust Version (MSRV) is now 1.90.0.
+
+### Bug fixes
+
+* `hawkeye` CLI now uses hawkeye-fmt of exactly the same version to format headers, instead of using the latest version of `hawkeye-fmt` that may not be compatible with the current version of `hawkeye`.
+
+### Improvements
+
+* Replace `anyhow` with `exn` for more informative error messages.
+
+## [6.4.2] 2026-02-07
+
+### Bug fixes
+
+* Set Git attributes for untracked folders as if it were committed now.
+
+## [6.4.1] 2026-01-13
+
+### Improvements
+
+* Use `TextLayout` for logging output to improve formatting and readability.
+
+## [6.4.0] 2026-01-12
+
+### Notable changes
+
+* `attrs.disk_file_created_year`, `attrs.git_file_created_year`, and `attrs.git_file_modified_year` are now integers instead of strings. Most use cases should not be affected.
+* `attrs.git_file_created_year` is now set even if the file is not tracked by Git. In this case, it will be set to the current year (as if it were committed now).
+* `attrs.git_file_modified_year` is now overwritten if the file is modified but not committed by Git. In this case, it will be set to the current year (as if it were committed now).
+* `attrs.disk_file_created_year` is then soft-deprecated. It can still be set, but it is recommended to use `attrs.git_file_created_year` and `attrs.git_file_modified_year` directly instead.
+
+The semantic changes above are breaking, but they should not affect most users and should always be what you want.
+
+* `additionalHeaders` and `headerPath` now search from the following paths in order:
+  1. The directory of the configuration file, a.k.a., config_dir.
+  2. The configured baseDir.
+  3. The current working directory.
+
+### Improvements
+
+* If `--config` is not specified, HawkEye will now search for `.licenserc.toml` in addition to `licenserc.toml`.
+
+## [6.3.0] 2025-10-09
+
+### New features
+
+* Add distribution against musl libc ([#196](https://github.com/fast/hawkeye/pull/196)).
+
+## [6.2.0] 2025-08-25
+
+### New features
+
+* Supports format Vue files: pattern = "vue" and headerType = "XML_STYLE".
+* Supports format Containerfile files: pattern = "Containerfile" and headerType = "SCRIPT_STYLE".
+* Add a shared flag to store lists of files to change ([#194](https://github.com/fast/hawkeye/pull/194)).
+
+## [6.1.1] 2025-06-11
+
+### New features
+
+* Supports format CommonJS files: pattern = "cjs" and headerType = "SLASHSTAR_STYLE".
+* Supports format Verilog files: pattern = "v" and headerType = "SLASHSTAR_STYLE".
+* Supports format SystemVerilog files: pattern = "sv" and headerType = "SLASHSTAR_STYLE".
+
+## [6.1.0] 2025-06-06
+
+### New features
+
+* `attrs.disk_file_created_year` can be used to replace nonexisting Git attrs like `{{attrs.git_file_created_year if attrs.git_file_created_year else attrs.disk_file_created_year }}`
+
+## [6.0.0] 2025-01-28
+
+### Breaking changes
+
+Now, HawkEye uses MiniJinja as the template engine.
+
+All the `properties` configured will be passed to the template engine as the `props` value, and thus:
+
+* Previous `${property}` should be replaced with `{{ props["property"] }}`.
+* Previous built-in variables `hawkeye.core.filename` is now `attrs.filename`.
+* Previous built-in variables `hawkeye.git.fileCreatedYear` is now `attrs.git_file_created_year`.
+* Previous built-in variables `hawkeye.git.fileModifiedYear` is now `attrs.git_file_modified_year`.
+
+New properties:
+
+* `attrs.git_authors` is a collection of authors of the file. You can join them with `, ` to get a string by `{{ attrs.git_authors | join(", ") }}`.
+
+### Notable changes
+
+Now, HawkEye would detect a leading BOM (Byte Order Mark) and remove it if it exists (#166). I tend to treat this as a bug fix, but it may affect the output of the header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## [7.0.0-alpha.1] 2026-08-19
+## v7.0.0-alpha.1 (2026-08-19)
 
 ### Breaking changes
 
@@ -26,13 +26,13 @@ All notable changes to this project will be documented in this file.
 
 See [MIGRATE.md](MIGRATE.md) for the v6-to-v7 procedure and semantic differences.
 
-## [6.5.1] 2026-02-14
+## v6.5.1 (2026-02-14)
 
 ### Bug fixes
 
 * Properly resolve relative paths when populating Git attributes for untracked folders.
 
-## [6.5.0] 2026-02-09
+## v6.5.0 (2026-02-09)
 
 ### Notable changes
 
@@ -46,19 +46,19 @@ See [MIGRATE.md](MIGRATE.md) for the v6-to-v7 procedure and semantic differences
 
 * Replace `anyhow` with `exn` for more informative error messages.
 
-## [6.4.2] 2026-02-07
+## v6.4.2 (2026-02-07)
 
 ### Bug fixes
 
 * Set Git attributes for untracked folders as if it were committed now.
 
-## [6.4.1] 2026-01-13
+## v6.4.1 (2026-01-13)
 
 ### Improvements
 
 * Use `TextLayout` for logging output to improve formatting and readability.
 
-## [6.4.0] 2026-01-12
+## v6.4.0 (2026-01-12)
 
 ### Notable changes
 
@@ -78,13 +78,13 @@ The semantic changes above are breaking, but they should not affect most users a
 
 * If `--config` is not specified, HawkEye will now search for `.licenserc.toml` in addition to `licenserc.toml`.
 
-## [6.3.0] 2025-10-09
+## v6.3.0 (2025-10-09)
 
 ### New features
 
 * Add distribution against musl libc ([#196](https://github.com/fast/hawkeye/pull/196)).
 
-## [6.2.0] 2025-08-25
+## v6.2.0 (2025-08-25)
 
 ### New features
 
@@ -92,7 +92,7 @@ The semantic changes above are breaking, but they should not affect most users a
 * Supports format Containerfile files: pattern = "Containerfile" and headerType = "SCRIPT_STYLE".
 * Add a shared flag to store lists of files to change ([#194](https://github.com/fast/hawkeye/pull/194)).
 
-## [6.1.1] 2025-06-11
+## v6.1.1 (2025-06-11)
 
 ### New features
 
@@ -100,13 +100,13 @@ The semantic changes above are breaking, but they should not affect most users a
 * Supports format Verilog files: pattern = "v" and headerType = "SLASHSTAR_STYLE".
 * Supports format SystemVerilog files: pattern = "sv" and headerType = "SLASHSTAR_STYLE".
 
-## [6.1.0] 2025-06-06
+## v6.1.0 (2025-06-06)
 
 ### New features
 
 * `attrs.disk_file_created_year` can be used to replace nonexisting Git attrs like `{{attrs.git_file_created_year if attrs.git_file_created_year else attrs.disk_file_created_year }}`
 
-## [6.0.0] 2025-01-28
+## v6.0.0 (2025-01-28)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 * Added human and JSON reports, stable exit-code categories, debug logging, and deterministic preservation of common file preambles and line endings.
 * Added cargo-binstall archives, a distroless multi-architecture container image, and Python and Docker pre-commit hooks.
 
-See [MIGRATE.md](https://github.com/fast/hawkeye/blob/main/MIGRATE.md) for the v6-to-v7 procedure and semantic differences.
+See [MIGRATE.md](MIGRATE.md) for the v6-to-v7 procedure and semantic differences.
 
 ## [6.5.1] 2026-02-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-homepage = "https://github.com/korandoru/hawkeye"
+homepage = "https://github.com/fast/hawkeye"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/korandoru/hawkeye"
+repository = "https://github.com/fast/hawkeye"
 rust-version = "1.89.0"
 
 [workspace.dependencies]

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,0 +1,354 @@
+# Migrating from HawkEye v6 to v7
+
+HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and several behaviors changed in addition to the move from camel case to snake case. This guide targets v6.5.x and v7.0.0-alpha.1 and is written as an executable migration checklist for either a person or a code agent.
+
+## Migration rules
+
+- Work on a clean branch and preserve the existing v6 config until the v7 result has been verified.
+- Do not add compatibility aliases to the v7 config. Replace every v6 field and invocation at its source.
+- Preserve the rendered license text, selected files, and failure policy unless this guide identifies an intentional v7 semantic change.
+- Treat exit code 2 as a migration or runtime error. Exit code 1 from `check` normally means the config loaded successfully but one or more files need attention.
+- Review a dry-run report before allowing `format` to write files. Do not silently accept `conflict` outcomes.
+- The canonical prerelease version is `7.0.0-alpha.1`, including the dot before `1`.
+
+## 1. Inventory the v6 setup
+
+Before editing, find every HawkEye input and integration:
+
+```shell
+find . -name 'licenserc.toml' -o -name '.licenserc.toml'
+rg -n 'hawkeye|hawkeye-fmt|headerPath|inlineHeader|additionalHeaders|useDefault' .
+```
+
+Record the following before conversion:
+
+- The selected config file and its `baseDir`.
+- Whether the header is inline, bundled, or loaded from a file.
+- Every additional header-style file referenced by `additionalHeaders`.
+- Custom entries under `[mapping.*]` and whether `useDefaultMapping` is disabled.
+- Negated exclude patterns and directories that were covered only by v6 default excludes.
+- CLI flags whose exit-code behavior is relied on by CI.
+- GitHub Actions, Docker, pre-commit, Cargo, or library integrations.
+
+## 2. Replace the config structure
+
+The following v6 config:
+
+```toml
+baseDir = "."
+headerPath = "Apache-2.0.txt"
+strictCheck = true
+useDefaultExcludes = true
+useDefaultMapping = true
+includes = ["**/*.rs", "**/*.toml"]
+excludes = ["generated/**"]
+keywords = ["copyright"]
+
+[properties]
+inceptionYear = 2022
+copyrightOwner = "Acme Developers"
+
+[git]
+ignore = "auto"
+attrs = "disable"
+```
+
+becomes:
+
+```toml
+[header]
+builtin = "Apache-2.0"
+keywords = ["copyright"]
+
+[files]
+root = "."
+includes = ["**/*.rs", "**/*.toml"]
+excludes = ["generated/**"]
+
+[props]
+inception_year = 2022
+copyright_owner = "Acme Developers"
+
+[git]
+ignore = "auto"
+file_attrs = "disable"
+```
+
+Use this field mapping for the rest of the config:
+
+| v6 | v7 | Migration action |
+| --- | --- | --- |
+| `baseDir` | `files.root` | Move the value under `[files]`. |
+| `inlineHeader` | `header.text` | Move the template under `[header]`. |
+| `headerPath` | `header.builtin` or `header.path` | Use a built-in key for a bundled header; otherwise use a path. |
+| `keywords` | `header.keywords` | Move the list under `[header]`. |
+| `includes` | `files.includes` | Move the list under `[files]`. |
+| `excludes` | `files.excludes` | Move the list and rewrite any negation. |
+| `properties` | `props` | Move values and update every template reference. |
+| `git.ignore` | `git.ignore` | No field rename. |
+| `git.attrs` | `git.file_attrs` | Rename the field. |
+| `[mapping.STYLE]` | `[[rules]]` | Convert mappings to ordered rule entries. |
+| `additionalHeaders` | `[styles.NAME]` | Inline each referenced style in the main config. |
+| `strictCheck` | none | Remove it; v7 uses safe literal style recognition. |
+| `useDefaultExcludes` | none | Remove it and make required exclusions explicit. |
+| `useDefaultMapping` | none | Remove it; built-in rules are always low-priority fallbacks. |
+
+v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the directory containing the selected config file, so rewrite the path when those directories differ. Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources.
+
+### Header source
+
+v7 requires exactly one header source:
+
+- `header.builtin = "Apache-2.0"`
+- `header.builtin = "Apache-2.0-ASF"`
+- `header.builtin = "Elastic-2.0"`
+- `header.path = "path/to/header.txt"`
+- `header.text = "Copyright ..."`
+
+When v6 sets both `inlineHeader` and `headerPath`, it silently prefers the inline value. Preserve that result by keeping only `header.text` in v7.
+
+The bundled v6 filenames lose their `.txt` suffix when used as v7 built-in keys. A custom file named `Apache-2.0.txt` must still use `header.path` if its content differs from the bundled template.
+
+### Properties and templates
+
+v6 converts every property to a string. v7 exposes the original TOML value under `props`, so integers remain integers, booleans remain booleans, and nested arrays or tables are allowed. Recheck comparisons, filters, and fallback expressions that assumed strings.
+
+The v7 bundled Apache and Elastic templates use snake-case property names. Convert:
+
+```jinja
+{{props["inceptionYear"]}} {{props["copyrightOwner"]}}
+```
+
+to:
+
+```jinja
+{{ props.inception_year }} {{ props.copyright_owner }}
+```
+
+Custom property keys are not restricted, but migrating them to snake case makes the config consistent. Rename each key and every reference together.
+
+v7 configures MiniJinja with strict undefined values. Missing properties now fail instead of rendering an empty value. File attributes that cannot be determined are `null`; express any fallback in the template rather than assuming the current year.
+
+The available attributes are:
+
+- `attrs.filename`
+- `attrs.disk_file_created_year`
+- `attrs.disk_file_modified_year`
+- `attrs.git_file_created_year`
+- `attrs.git_file_modified_year`
+- `attrs.git_authors`
+
+### File selection
+
+An empty `files.includes` list selects every discovered file. Both include and exclude patterns are relative to `files.root` and use Git-ignore-style matching.
+
+v7 does not accept `!` negation in either list. Rewrite a v6 exclusion such as `build/**` plus `!build/keep.rs` so the broad exclusion no longer covers the file that must remain selected. Do not copy the negated pattern verbatim.
+
+v6 maintained a large default blacklist for build output, dependency directories, editor state, and metadata files. v7 removes that blacklist. Git ignore rules handle these paths in a normal repository; add project-specific `files.excludes` when generated or vendored files are not ignored, especially when `git.ignore = "disable"` or the scan runs outside a repository.
+
+The header template selected by `header.path` is automatically excluded. `.git` is always excluded. v7 follows file symlinks but does not recurse through directory symlinks.
+
+### Rules and styles
+
+v6 mappings are keyed by style and stored without a useful declaration order. v7 rules are an ordered list. User rules run before built-in rules, and the first matching user rule wins.
+
+Convert this v6 mapping:
+
+```toml
+[mapping.DOUBLESLASH_STYLE]
+extensions = ["foo"]
+filenames = ["Foo.config"]
+```
+
+to:
+
+```toml
+[[rules]]
+extensions = ["foo"]
+filenames = ["Foo.config"]
+style_out = "doubleslash"
+```
+
+`style_out` is the canonical style written by `format`. An empty `styles_in` accepts only `style_out`. When existing files legitimately use more than one style, list the complete accepted set and include `style_out`:
+
+```toml
+styles_in = ["doubleslash", "slashstar"]
+```
+
+Do not recreate a v6 mapping that is already covered by a v7 built-in rule unless the project needs to override its output or accepted styles. The current built-in selectors are documented in [`rules.toml`](hawkeye/src/builtin/rules.toml).
+
+v6 style names are case-insensitive; v7 names are case-sensitive. These common built-in names map as follows:
+
+| v6 | v7 | v6 | v7 |
+| --- | --- | --- | --- |
+| `DOUBLESLASH_STYLE` | `doubleslash` | `SLASHSTAR_STYLE` | `slashstar` |
+| `TRIPLESLASH_STYLE` | `tripleslash` | `JAVADOC_STYLE` | `javadoc` |
+| `SCRIPT_STYLE` | `script` | `DOUBLEDASHES_STYLE` | `doubledashes` |
+| `XML_STYLE` | `xml` | `XML_PER_LINE` | `xml_per_line` |
+| `PERCENT_STYLE` | `percent` | `PERCENT3_STYLE` | `percent3` |
+| `SEMICOLON_STYLE` | `semicolon` | `APOSTROPHE_STYLE` | `apostrophe` |
+| `EXCLAMATION_STYLE` | `exclamation` | `EXCLAMATION3_STYLE` | `exclamation3` |
+| `DOUBLETILDE_STYLE` | `doubletilde` | `BATCH` | `batch` |
+| `HAML_STYLE` | `haml` | `BRACESSTAR_STYLE` | `bracesstar` |
+| `SHARPSTAR_STYLE` | `sharpstar` | `MUSTACHE_STYLE` | `mustache` |
+| `MVEL_STYLE` | `mvel` | `FTL` | `ftl` |
+| `FTL_ALT` | `ftl_alt` | `DYNASCRIPT_STYLE` | `dynascript` |
+| `DYNASCRIPT3_STYLE` | `dynascript3` | `ASP` | `asp` |
+| `PHP` | `slashstar` | `LUA` | `lua` |
+| `ASCIIDOC_STYLE` | `asciidoc` | `LINE_BLOCK_STYLE` | `line_block` |
+
+For `SCALA_STYLE`, `JAVAPKG_STYLE`, `UNKNOWN`, or any project-defined style, create a custom v7 style instead of guessing a built-in replacement. Even mapped built-ins may produce slightly different canonical whitespace, so inspect the dry-run diff.
+
+Move every style from files named by `additionalHeaders` into the main config. A v6 line style:
+
+```toml
+[MY_STYLE]
+multipleLines = false
+beforeEachLine = "// "
+afterEachLine = ""
+padLines = false
+```
+
+becomes:
+
+```toml
+[styles.my_style]
+kind = "line"
+prefix = "// "
+suffix = ""
+pad_lines = false
+```
+
+For a v6 style with `multipleLines = true`, use `kind = "block"`, map `firstLine` to `start`, `beforeEachLine` to `prefix`, `afterEachLine` to `suffix`, and `endLine` to `end`. Remove newline sentinels from `start` and `end`; v7 controls line endings itself.
+
+v7 derives recognition from the literal line or block delimiters. It has no configurable equivalents for `firstLineDetectionPattern`, `lastLineDetectionPattern`, `skipLinePattern`, or `allowBlankLines`. It natively preserves a UTF-8 BOM, shebangs, XML and PHP declarations, HTML doctypes, YAML directives, and common Python or Ruby magic comments. If a project relies on another `skipLinePattern`, stop and report that case instead of silently dropping it.
+
+`strictCheck = false` also has no direct replacement. v7 does not use whitespace-folded or similarity-based matching. A loosely matched v6 header may become `replace` when it is safely recognized or `conflict` when it is not safe to edit automatically.
+
+### Git attributes
+
+Rename `git.attrs` to `git.file_attrs`. Both Git fields accept `"disable"`, `"auto"`, or `"enable"`.
+
+v7 defines Git creation as the latest addition in the current exact-path lifetime. Delete-and-recreate and rename-to-a-new-path both start a new lifetime. Merge history follows the parent state that produced the current file. This intentionally differs from treating every historical occurrence of the path as one continuous file.
+
+`git.file_attrs` remains disabled by default because a long-lived file can require substantial history traversal. `enable` requires a complete, non-shallow repository; `auto` falls back when Git attributes are unavailable. v7 reads Git data in-process with `gix` and does not require a `git` executable at runtime.
+
+## 3. Update command lines
+
+| v6 | v7 |
+| --- | --- |
+| `--fail-if-unknown` | `--fail-on-unknown` |
+| `--output report.json` | `--output-format json > report.json` |
+| `check --fail-if-missing=true` | `check` already fails when a change is required |
+| `check --fail-if-missing=false` | No equivalent; consume the JSON report if a non-failing audit is required |
+| `format --fail-if-updated=true` | `format --fail-on-change` |
+| `format --fail-if-updated=false` | `format` |
+| `remove --fail-if-updated=true` | `remove --fail-on-change` |
+| `remove --fail-if-updated=false` | `remove` |
+
+The v7 `format` and `remove` commands succeed after making changes unless `--fail-on-change` is present. CI should normally use `hawkeye check`; use `--fail-on-change` only when an editing command must preserve the old failure policy.
+
+v7 `--dry-run` performs no writes. v6 created sibling `.formatted` or `.removed` files; remove any workflow that reads those files and consume the human or JSON report instead.
+
+All reports now go to stdout, while logs and errors go to stderr. JSON has one schema for every command:
+
+```json
+{
+  "files": [
+    {
+      "path": "src/lib.rs",
+      "outcome": "replace"
+    }
+  ]
+}
+```
+
+The possible outcomes are `clean`, `add`, `replace`, `remove`, `conflict`, and `unsupported`.
+
+v7 also accepts files and directories after the subcommand. With no paths it scans the configured file set:
+
+```shell
+hawkeye check
+hawkeye check src/lib.rs src/bin
+```
+
+## 4. Update integrations
+
+### GitHub Actions
+
+The v6 repository action is removed. Install and invoke the released CLI explicitly:
+
+```yaml
+- uses: actions/checkout@v7
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall hawkeye@7.0.0-alpha.1 --no-confirm
+- run: hawkeye check
+```
+
+### Docker
+
+Use the transferred image namespace and mount the repository at `/workspace`:
+
+```shell
+docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0-alpha.1 check
+```
+
+### pre-commit
+
+Update the repository and revision:
+
+```yaml
+repos:
+  - repo: https://github.com/fast/hawkeye
+    rev: v7.0.0-alpha.1
+    hooks:
+      - id: hawkeye-format
+```
+
+v7 hooks pass pre-commit's selected files to HawkEye. To retain a deliberate full-repository scan, set both `pass_filenames: false` and `always_run: true` in the consuming repository.
+
+### Rust library
+
+The separate `hawkeye-fmt` crate is replaced by the `hawkeye` library. A minimal dependency is:
+
+```toml
+hawkeye = { version = "7.0.0-alpha.1", default-features = false }
+```
+
+The v6 callback and document APIs are not preserved. Build a `Config`, create an `Engine`, and select an explicit `Scope`:
+
+```rust
+use hawkeye::Config;
+use hawkeye::Engine;
+use hawkeye::Scope;
+
+let config = Config::load("licenserc.toml")?;
+let engine = Engine::new(config)?;
+let report = engine.check(Scope::All)?;
+# Ok::<(), hawkeye::Error>(())
+```
+
+`Engine::format` and `Engine::remove` return pending edits. Call `apply` to write them or `into_report` to inspect them without writing.
+
+## 5. Verify the migration
+
+Install the exact prerelease and confirm the selected binary:
+
+```shell
+cargo install hawkeye --version 7.0.0-alpha.1 --locked
+hawkeye --version
+```
+
+Then verify in this order:
+
+1. Run `hawkeye check --output-format json > hawkeye-report.json`. Exit code 1 is expected when files need changes; exit code 2 means the config or runtime still needs repair.
+2. Inspect every `conflict` and `unsupported` entry. Fix the rule, style, template, or file selection rather than forcing an edit.
+3. Run `hawkeye format --dry-run --output-format json > hawkeye-format.json` and review all `add` and `replace` outcomes.
+4. Ensure the Git worktree is clean, run `hawkeye format`, and review `git diff` for header text, whitespace, preambles, and line endings.
+5. Run `hawkeye check` again. It must exit 0.
+6. Run the project's normal tests and its GitHub Actions, Docker, or pre-commit integration as applicable.
+7. Remove obsolete v6 style files and integration code only after the v7 check passes.
+
+For a complete annotated v7 config, see the [Configuration](README.md#configuration) section in the README.

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -76,22 +76,22 @@ file_attrs = "disable"
 
 Use this field mapping for the rest of the config:
 
-| v6 | v7 | Migration action |
-| --- | --- | --- |
-| `baseDir` | `files.root` | Move the value under `[files]`. |
-| `inlineHeader` | `header.text` | Move the template under `[header]`. |
-| `headerPath` | `header.builtin` or `header.path` | Use a built-in key for a bundled header; otherwise use a path. |
-| `keywords` | `header.keywords` | Move the list under `[header]`. |
-| `includes` | `files.includes` | Move the list under `[files]`. |
-| `excludes` | `files.excludes` | Move the list and rewrite any negation. |
-| `properties` | `props` | Move values and update every template reference. |
-| `git.ignore` | `git.ignore` | No field rename. |
-| `git.attrs` | `git.file_attrs` | Rename the field. |
-| `[mapping.STYLE]` | `[[rules]]` | Convert mappings to ordered rule entries. |
-| `additionalHeaders` | `[styles.NAME]` | Inline each referenced style in the main config. |
-| `strictCheck` | none | Remove it; v7 uses safe literal style recognition. |
-| `useDefaultExcludes` | none | Remove it and make required exclusions explicit. |
-| `useDefaultMapping` | none | Remove it; built-in rules are always low-priority fallbacks. |
+| v6                   | v7                                | Migration action                                               |
+|----------------------|-----------------------------------|----------------------------------------------------------------|
+| `baseDir`            | `files.root`                      | Move the value under `[files]`.                                |
+| `inlineHeader`       | `header.text`                     | Move the template under `[header]`.                            |
+| `headerPath`         | `header.builtin` or `header.path` | Use a built-in key for a bundled header; otherwise use a path. |
+| `keywords`           | `header.keywords`                 | Move the list under `[header]`.                                |
+| `includes`           | `files.includes`                  | Move the list under `[files]`.                                 |
+| `excludes`           | `files.excludes`                  | Move the list and rewrite any negation.                        |
+| `properties`         | `props`                           | Move values and update every template reference.               |
+| `git.ignore`         | `git.ignore`                      | No field rename.                                               |
+| `git.attrs`          | `git.file_attrs`                  | Rename the field.                                              |
+| `[mapping.STYLE]`    | `[[rules]]`                       | Convert mappings to ordered rule entries.                      |
+| `additionalHeaders`  | `[styles.NAME]`                   | Inline each referenced style in the main config.               |
+| `strictCheck`        | none                              | Remove it; v7 uses safe literal style recognition.             |
+| `useDefaultExcludes` | none                              | Remove it and make required exclusions explicit.               |
+| `useDefaultMapping`  | none                              | Remove it; built-in rules are always low-priority fallbacks.   |
 
 v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the directory containing the selected config file, so rewrite the path when those directories differ. Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources.
 
@@ -179,23 +179,23 @@ Do not recreate a v6 mapping that is already covered by a v7 built-in rule unles
 
 v6 style names are case-insensitive; v7 names are case-sensitive. These common built-in names map as follows:
 
-| v6 | v7 | v6 | v7 |
-| --- | --- | --- | --- |
-| `DOUBLESLASH_STYLE` | `doubleslash` | `SLASHSTAR_STYLE` | `slashstar` |
-| `TRIPLESLASH_STYLE` | `tripleslash` | `JAVADOC_STYLE` | `javadoc` |
-| `SCRIPT_STYLE` | `script` | `DOUBLEDASHES_STYLE` | `doubledashes` |
-| `XML_STYLE` | `xml` | `XML_PER_LINE` | `xml_per_line` |
-| `PERCENT_STYLE` | `percent` | `PERCENT3_STYLE` | `percent3` |
-| `SEMICOLON_STYLE` | `semicolon` | `APOSTROPHE_STYLE` | `apostrophe` |
+| v6                  | v7            | v6                   | v7             |
+|---------------------|---------------|----------------------|----------------|
+| `DOUBLESLASH_STYLE` | `doubleslash` | `SLASHSTAR_STYLE`    | `slashstar`    |
+| `TRIPLESLASH_STYLE` | `tripleslash` | `JAVADOC_STYLE`      | `javadoc`      |
+| `SCRIPT_STYLE`      | `script`      | `DOUBLEDASHES_STYLE` | `doubledashes` |
+| `XML_STYLE`         | `xml`         | `XML_PER_LINE`       | `xml_per_line` |
+| `PERCENT_STYLE`     | `percent`     | `PERCENT3_STYLE`     | `percent3`     |
+| `SEMICOLON_STYLE`   | `semicolon`   | `APOSTROPHE_STYLE`   | `apostrophe`   |
 | `EXCLAMATION_STYLE` | `exclamation` | `EXCLAMATION3_STYLE` | `exclamation3` |
-| `DOUBLETILDE_STYLE` | `doubletilde` | `BATCH` | `batch` |
-| `HAML_STYLE` | `haml` | `BRACESSTAR_STYLE` | `bracesstar` |
-| `SHARPSTAR_STYLE` | `sharpstar` | `MUSTACHE_STYLE` | `mustache` |
-| `MVEL_STYLE` | `mvel` | `FTL` | `ftl` |
-| `FTL_ALT` | `ftl_alt` | `DYNASCRIPT_STYLE` | `dynascript` |
-| `DYNASCRIPT3_STYLE` | `dynascript3` | `ASP` | `asp` |
-| `PHP` | `slashstar` | `LUA` | `lua` |
-| `ASCIIDOC_STYLE` | `asciidoc` | `LINE_BLOCK_STYLE` | `line_block` |
+| `DOUBLETILDE_STYLE` | `doubletilde` | `BATCH`              | `batch`        |
+| `HAML_STYLE`        | `haml`        | `BRACESSTAR_STYLE`   | `bracesstar`   |
+| `SHARPSTAR_STYLE`   | `sharpstar`   | `MUSTACHE_STYLE`     | `mustache`     |
+| `MVEL_STYLE`        | `mvel`        | `FTL`                | `ftl`          |
+| `FTL_ALT`           | `ftl_alt`     | `DYNASCRIPT_STYLE`   | `dynascript`   |
+| `DYNASCRIPT3_STYLE` | `dynascript3` | `ASP`                | `asp`          |
+| `PHP`               | `slashstar`   | `LUA`                | `lua`          |
+| `ASCIIDOC_STYLE`    | `asciidoc`    | `LINE_BLOCK_STYLE`   | `line_block`   |
 
 For `SCALA_STYLE`, `JAVAPKG_STYLE`, `UNKNOWN`, or any project-defined style, create a custom v7 style instead of guessing a built-in replacement. Even mapped built-ins may produce slightly different canonical whitespace, so inspect the dry-run diff.
 
@@ -235,16 +235,16 @@ v7 defines Git creation as the latest addition in the current exact-path lifetim
 
 ## 3. Update command lines
 
-| v6 | v7 |
-| --- | --- |
-| `--fail-if-unknown` | `--fail-on-unknown` |
-| `--output report.json` | `--output-format json > report.json` |
-| `check --fail-if-missing=true` | `check` already fails when a change is required |
-| `check --fail-if-missing=false` | No equivalent; consume the JSON report if a non-failing audit is required |
-| `format --fail-if-updated=true` | `format --fail-on-change` |
-| `format --fail-if-updated=false` | `format` |
-| `remove --fail-if-updated=true` | `remove --fail-on-change` |
-| `remove --fail-if-updated=false` | `remove` |
+| v6                               | v7                                                                        |
+|----------------------------------|---------------------------------------------------------------------------|
+| `--fail-if-unknown`              | `--fail-on-unknown`                                                       |
+| `--output report.json`           | `--output-format json > report.json`                                      |
+| `check --fail-if-missing=true`   | `check` already fails when a change is required                           |
+| `check --fail-if-missing=false`  | No equivalent; consume the JSON report if a non-failing audit is required |
+| `format --fail-if-updated=true`  | `format --fail-on-change`                                                 |
+| `format --fail-if-updated=false` | `format`                                                                  |
+| `remove --fail-if-updated=true`  | `remove --fail-on-change`                                                 |
+| `remove --fail-if-updated=false` | `remove`                                                                  |
 
 The v7 `format` and `remove` commands succeed after making changes unless `--fail-on-change` is present. CI should normally use `hawkeye check`; use `--fail-on-change` only when an editing command must preserve the old failure policy.
 

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -282,8 +282,7 @@ The v6 repository action is removed. Install and invoke the released CLI explici
 - uses: actions/checkout@v7
 - uses: taiki-e/install-action@v2
   with:
-    tool: cargo-binstall
-- run: cargo binstall hawkeye@7.0.0-alpha.1 --no-confirm
+    tool: hawkeye@7.0.0-alpha.1
 - run: hawkeye check
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,15 +181,15 @@ styles_in = ["doubleslash", "slashstar"]
 
 Templates use MiniJinja with strict undefined values, auto-escaping disabled, and its standard built-in filters, tests, and functions. HawkEye does not enable template includes or external loaders. The template context contains:
 
-| Value                           | Meaning                                                                         |
-| ------------------------------- | ------------------------------------------------------------------------------- |
-| `props`                         | The complete user-defined `[props]` table.                                      |
-| `attrs.filename`                | The current file name.                                                          |
-| `attrs.disk_file_created_year`  | The filesystem creation year, or `null` when unavailable.                       |
-| `attrs.disk_file_modified_year` | The filesystem modification year, or `null` when unavailable.                   |
-| `attrs.git_file_created_year`   | The year the current exact-path lifetime began, or `null` when unavailable.      |
-| `attrs.git_file_modified_year`  | The latest year in the current exact-path history, including worktree changes.  |
-| `attrs.git_authors`             | Sorted distinct author names from the current exact-path history.               |
+| Value                           | Meaning                                                                        |
+|---------------------------------|--------------------------------------------------------------------------------|
+| `props`                         | The complete user-defined `[props]` table.                                     |
+| `attrs.filename`                | The current file name.                                                         |
+| `attrs.disk_file_created_year`  | The filesystem creation year, or `null` when unavailable.                      |
+| `attrs.disk_file_modified_year` | The filesystem modification year, or `null` when unavailable.                  |
+| `attrs.git_file_created_year`   | The year the current exact-path lifetime began, or `null` when unavailable.    |
+| `attrs.git_file_modified_year`  | The latest year in the current exact-path history, including worktree changes. |
+| `attrs.git_authors`             | Sorted distinct author names from the current exact-path history.              |
 
 HawkEye never substitutes the current year for an unavailable value. Templates that need a fallback must express it explicitly.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 [msrv-badge]: https://img.shields.io/badge/MSRV-1.89-green?logo=rust
 [license-badge]: https://img.shields.io/crates/l/hawkeye
 [license-url]: https://www.apache.org/licenses/LICENSE-2.0
-[actions-badge]: https://github.com/korandoru/hawkeye/actions/workflows/ci.yml/badge.svg
-[actions-url]: https://github.com/korandoru/hawkeye/actions/workflows/ci.yml
+[actions-badge]: https://github.com/fast/hawkeye/actions/workflows/ci.yml/badge.svg
+[actions-url]: https://github.com/fast/hawkeye/actions/workflows/ci.yml
 
 HawkEye checks, formats, and removes source-file license headers. The crate provides both the `hawkeye` command-line tool and a Rust library.
 
@@ -91,7 +91,7 @@ Exit code 0 means the selected policy passed. Exit code 1 means `check` found a 
 The distroless image runs HawkEye in `/workspace`. Pass the host user when formatting a bind mount so that writes retain the expected ownership:
 
 ```shell
-docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/korandoru/hawkeye:v7.0.0-alpha.1 check
+docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0-alpha.1 check
 ```
 
 ### GitHub Actions
@@ -113,7 +113,7 @@ The default hook installs the matching HawkEye source revision in pre-commit's i
 
 ```yaml
 repos:
-  - repo: https://github.com/korandoru/hawkeye
+  - repo: https://github.com/fast/hawkeye
     rev: v7.0.0-alpha.1
     hooks:
       - id: hawkeye-format

--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ hawkeye = { version = "7.0.0-alpha.1", default-features = false }
 
 ## Compatibility
 
-HawkEye v7 uses a new snake-case configuration format and does not accept v6 field names. A v6 config must be migrated before use with v7.
+HawkEye v7 uses a new snake-case configuration format and does not accept v6 field names. Follow [MIGRATE.md](https://github.com/fast/hawkeye/blob/main/MIGRATE.md) to migrate a v6 configuration, command line, and integration.
+
+Release summaries are recorded in [CHANGELOG.md](https://github.com/fast/hawkeye/blob/main/CHANGELOG.md).
 
 The minimum supported Rust version is 1.89.0. It may be raised in a minor release; patch releases preserve the minimum version of their corresponding minor release.
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ hawkeye = { version = "7.0.0-alpha.1", default-features = false }
 
 ## Compatibility
 
-HawkEye v7 uses a new snake-case configuration format and does not accept v6 field names. Follow [MIGRATE.md](https://github.com/fast/hawkeye/blob/main/MIGRATE.md) to migrate a v6 configuration, command line, and integration.
+HawkEye v7 uses a new snake-case configuration format and does not accept v6 field names. Follow [MIGRATE.md](MIGRATE.md) to migrate a v6 configuration, command line, and integration.
 
-Release summaries are recorded in [CHANGELOG.md](https://github.com/fast/hawkeye/blob/main/CHANGELOG.md).
+Release summaries are recorded in [CHANGELOG.md](CHANGELOG.md).
 
 The minimum supported Rust version is 1.89.0. It may be raised in a minor release; patch releases preserve the minimum version of their corresponding minor release.
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,13 @@ docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fa
 
 ### GitHub Actions
 
-Install the released binary with cargo-binstall and invoke HawkEye directly; no HawkEye-specific action is required:
+Install the released binary and invoke HawkEye directly; no HawkEye-specific action is required:
 
 ```yaml
 - uses: actions/checkout@v7
 - uses: taiki-e/install-action@v2
   with:
-    tool: cargo-binstall
-- run: cargo binstall hawkeye@7.0.0-alpha.1 --no-confirm
+    tool: hawkeye@7.0.0-alpha.1
 - run: hawkeye check
 ```
 


### PR DESCRIPTION
## Summary

- Update crate metadata, badges, pre-commit examples, Docker references, and the semantic check link for the move to `fast/hawkeye`.
- Add `MIGRATE.md` as an executable v6-to-v7 migration guide for people and code agents, covering config, rules, styles, CLI behavior, Git semantics, integrations, and verification.
- Restore `CHANGELOG.md` with the v6 history and a focused `7.0.0-alpha.1` release summary for cargo-dist release notes.
- Validate the release with `cargo x lint`, `cargo x test`, `dist plan`, `cargo publish --dry-run`, and a full `cargo release 7.0.0-alpha.1` dry run.