### PR TITLE
chore: prepare v7.0.0 release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,9 +152,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=edge,branch=main
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
+            type=semver,pattern={{raw}}
       - name: Push manifest
         env:
           AMD64_DIGEST: ${{ needs.amd64.outputs.digest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## v7.0.0-alpha.1 (2026-08-19)
+## v7.0.0 (2026-08-19)
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "hawkeye"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 dependencies = [
  "clap",
  "exn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-hawkeye = { version = "7.0.0-alpha.1", path = "hawkeye" }
+hawkeye = { version = "7.0.0", path = "hawkeye" }
 
 # crates.io dependencies
 clap = { version = "4.6.6", features = ["derive"] }

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,6 +1,6 @@
 # Migrating from HawkEye v6 to v7
 
-HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and several behaviors changed in addition to the move from camel case to snake case. This guide targets v6.5.x and v7.0.0-alpha.1 and is written as an executable migration checklist for either a person or a code agent.
+HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and several behaviors changed in addition to the move from camel case to snake case. This guide targets v6.5.x and v7.0.0 and is written as an executable migration checklist for either a person or a code agent.
 
 ## Migration rules
 
@@ -9,7 +9,6 @@ HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and severa
 - Preserve the rendered license text, selected files, and failure policy unless this guide identifies an intentional v7 semantic change.
 - Treat exit code 2 as a migration or runtime error. Exit code 1 from `check` normally means the config loaded successfully but one or more files need attention.
 - Review a dry-run report before allowing `format` to write files. Do not silently accept `conflict` outcomes.
-- The canonical prerelease version is `7.0.0-alpha.1`, including the dot before `1`.
 
 ## 1. Inventory the v6 setup
 
@@ -282,7 +281,7 @@ The v6 repository action is removed. Install and invoke the released CLI explici
 - uses: actions/checkout@v7
 - uses: taiki-e/install-action@v2
   with:
-    tool: hawkeye@7.0.0-alpha.1
+    tool: hawkeye@7.0.0
 - run: hawkeye check
 ```
 
@@ -291,7 +290,7 @@ The v6 repository action is removed. Install and invoke the released CLI explici
 Use the transferred image namespace and mount the repository at `/workspace`:
 
 ```shell
-docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0-alpha.1 check
+docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0 check
 ```
 
 ### pre-commit
@@ -301,7 +300,7 @@ Update the repository and revision:
 ```yaml
 repos:
   - repo: https://github.com/fast/hawkeye
-    rev: v7.0.0-alpha.1
+    rev: v7.0.0
     hooks:
       - id: hawkeye-format
 ```
@@ -313,7 +312,7 @@ v7 hooks pass pre-commit's selected files to HawkEye. To retain a deliberate ful
 The separate `hawkeye-fmt` crate is replaced by the `hawkeye` library. A minimal dependency is:
 
 ```toml
-hawkeye = { version = "7.0.0-alpha.1", default-features = false }
+hawkeye = { version = "7.0.0", default-features = false }
 ```
 
 The v6 callback and document APIs are not preserved. Build a `Config`, create an `Engine`, and select an explicit `Scope`:
@@ -333,10 +332,10 @@ let report = engine.check(Scope::All)?;
 
 ## 5. Verify the migration
 
-Install the exact prerelease and confirm the selected binary:
+Install the exact release and confirm the selected binary:
 
 ```shell
-cargo install hawkeye --version 7.0.0-alpha.1 --locked
+cargo install hawkeye --version 7.0.0 --locked
 hawkeye --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ HawkEye checks, formats, and removes source-file license headers. The crate prov
 The recommended way to install the command-line tool is to let [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) download a prebuilt release:
 
 ```shell
-cargo binstall hawkeye@7.0.0-alpha.1
+cargo binstall hawkeye@7.0.0
 ```
 
 To build from source instead, use Cargo:
 
 ```shell
-cargo install hawkeye --version 7.0.0-alpha.1 --locked
+cargo install hawkeye --version 7.0.0 --locked
 ```
 
 Prebuilt releases cover the following platforms:
@@ -91,7 +91,7 @@ Exit code 0 means the selected policy passed. Exit code 1 means `check` found a 
 The distroless image runs HawkEye in `/workspace`. Pass the host user when formatting a bind mount so that writes retain the expected ownership:
 
 ```shell
-docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0-alpha.1 check
+docker run --rm --user "$(id -u):$(id -g)" --volume "$PWD:/workspace" ghcr.io/fast/hawkeye:v7.0.0 check
 ```
 
 ### GitHub Actions
@@ -102,7 +102,7 @@ Install the released binary and invoke HawkEye directly; no HawkEye-specific act
 - uses: actions/checkout@v7
 - uses: taiki-e/install-action@v2
   with:
-    tool: hawkeye@7.0.0-alpha.1
+    tool: hawkeye@7.0.0
 - run: hawkeye check
 ```
 
@@ -113,7 +113,7 @@ The default hook installs the matching HawkEye source revision in pre-commit's i
 ```yaml
 repos:
   - repo: https://github.com/fast/hawkeye
-    rev: v7.0.0-alpha.1
+    rev: v7.0.0
     hooks:
       - id: hawkeye-format
 ```
@@ -231,7 +231,7 @@ Each operation accepts a `Scope`. `Scope::All` processes the configured file set
 The default `application` feature builds the command-line tool. Library-only users can omit its command-specific dependencies:
 
 ```toml
-hawkeye = { version = "7.0.0-alpha.1", default-features = false }
+hawkeye = { version = "7.0.0", default-features = false }
 ```
 
 ## Compatibility

--- a/hawkeye/Cargo.toml
+++ b/hawkeye/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "A license header checker and formatter."
 name = "hawkeye"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

- prepare crate metadata, release notes, and user documentation for v7.0.0
- preserve the v-prefixed Git release tag in published container image tags
- keep the moving edge image tag for main-branch builds