### PR TITLE
fix: recognize conventional block layouts

### DIFF
--- a/hawkeye/src/builtin/styles.toml
+++ b/hawkeye/src/builtin/styles.toml
@@ -85,7 +85,6 @@ end = " */"
 [styles.xml]
 kind = "block"
 start = "<!--"
-prefix = "    "
 end = "-->"
 
 [styles.lua]

--- a/hawkeye/src/engine/analyze.rs
+++ b/hawkeye/src/engine/analyze.rs
@@ -126,6 +126,9 @@ fn has_keywords(body: &str, keywords: &[String]) -> bool {
 fn safe_to_replace(candidate: &str, header: &str, keywords: &[String]) -> bool {
     // Comment syntax finds the candidate range; this semantic check prevents an adjacent ordinary
     // comment from being consumed merely because it uses the same style.
+    if candidate.split_whitespace().eq(header.split_whitespace()) {
+        return true;
+    }
     candidate.lines().count() <= header.lines().count()
         && candidate
             .lines()
@@ -348,9 +351,12 @@ fn parse_block_style(
     for (content, line_range) in lines {
         if content == closing {
             let end = line_range.start + content.len();
+            // Header templates cannot retain outer blank lines, while block comments commonly
+            // use them as visual padding immediately inside the delimiters.
+            let body = body.join("\n");
             return Some(StyleMatch {
                 range: start..end,
-                body: body.join("\n"),
+                body: body.trim_matches('\n').to_owned(),
             });
         }
         body.push(strip_affixes(content, prefix, suffix, false)?);

--- a/hawkeye/tests/test/format.rs
+++ b/hawkeye/tests/test/format.rs
@@ -140,7 +140,7 @@ fn format_preserves_preambles_and_existing_line_endings() {
     );
     assert_eq!(
         project.read("document.xml"),
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!--\n    Copyright 2026 Acme Labs\n-->\n\n<project />\n"
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!--\nCopyright 2026 Acme Labs\n-->\n\n<project />\n"
     );
     assert_eq!(
         project.read("document.yaml"),
@@ -161,6 +161,84 @@ fn format_preserves_preambles_and_existing_line_endings() {
     assert_eq!(
         project.read("main.php"),
         "<?php declare(strict_types=1);\n/*\n * Copyright 2026 Acme Labs\n */\n\necho \"hello\";\n"
+    );
+    assert_exit(&project.run(["check"]), 0);
+}
+
+#[test]
+fn conventional_block_comment_layouts_are_recognized() {
+    let project = Project::empty();
+    project.write(
+        "licenserc.toml",
+        r#"[header]
+builtin = "Apache-2.0-ASF"
+
+[files]
+includes = ["**/*.java", "**/*.xml"]
+"#,
+    );
+    project.write(
+        "Example.java",
+        r#"/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+class Example {}
+"#,
+    );
+    project.write(
+        "pom.xml",
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project />
+"#,
+    );
+
+    let checked = project.run(["check", "--output-format=json"]);
+    assert_exit(&checked, 1);
+    assert_report(
+        &checked,
+        &[("Example.java", "replace"), ("pom.xml", "clean")],
+    );
+
+    let formatted = project.run(["format", "--output-format=json"]);
+    assert_exit(&formatted, 0);
+    assert_report(
+        &formatted,
+        &[("Example.java", "replace"), ("pom.xml", "clean")],
     );
     assert_exit(&project.run(["check"]), 0);
 }


### PR DESCRIPTION
## Summary

- recognize complete license headers when only whitespace, wrapping, or block padding differs
- emit built-in XML headers without forced content indentation
- cover conventional Java and XML layouts through the CLI integration suite

Closes #220