### PR TITLE
fix: identify undefined template expressions

### DIFF
--- a/hawkeye/src/template.rs
+++ b/hawkeye/src/template.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeMap;
 
 use minijinja::AutoEscape;
 use minijinja::Environment;
+use minijinja::ErrorKind as TemplateErrorKind;
 use minijinja::UndefinedBehavior;
 
 use crate::Error;
@@ -51,7 +52,7 @@ impl HeaderTemplate {
             .render(minijinja::context! { props, attrs })
             .map_err(|err| {
                 Error::new(ErrorKind::ConfigInvalid, "cannot render header template")
-                    .with_source(err)
+                    .with_source(render_error_source(&err, template.source()))
             })?;
         let normalized = rendered.replace("\r\n", "\n").replace('\r', "\n");
         let normalized = normalized.trim_matches('\n').to_owned();
@@ -68,5 +69,28 @@ impl HeaderTemplate {
             ));
         }
         Ok(normalized)
+    }
+}
+
+fn render_error_source(error: &minijinja::Error, template_source: &str) -> String {
+    if error.kind() != TemplateErrorKind::UndefinedError || error.detail().is_some() {
+        return error.to_string();
+    }
+
+    let Some(expression) = error
+        .range()
+        .and_then(|range| template_source.get(range))
+        .map(str::trim)
+        .filter(|expression| !expression.is_empty())
+    else {
+        return error.to_string();
+    };
+
+    match error.name() {
+        Some(name) => format!(
+            "undefined value in template expression {expression:?} (in {name}:{})",
+            error.line().unwrap_or(0)
+        ),
+        None => format!("undefined value in template expression {expression:?}"),
     }
 }

--- a/hawkeye/src/template.rs
+++ b/hawkeye/src/template.rs
@@ -51,8 +51,11 @@ impl HeaderTemplate {
         let rendered = template
             .render(minijinja::context! { props, attrs })
             .map_err(|err| {
-                Error::new(ErrorKind::ConfigInvalid, "cannot render header template")
-                    .with_source(render_error_source(&err, template.source()))
+                let detail = render_error_message(&err, template.source());
+                Error::new(
+                    ErrorKind::ConfigInvalid,
+                    format!("cannot render header template: {detail}"),
+                )
             })?;
         let normalized = rendered.replace("\r\n", "\n").replace('\r', "\n");
         let normalized = normalized.trim_matches('\n').to_owned();
@@ -72,7 +75,7 @@ impl HeaderTemplate {
     }
 }
 
-fn render_error_source(error: &minijinja::Error, template_source: &str) -> String {
+fn render_error_message(error: &minijinja::Error, template_source: &str) -> String {
     if error.kind() != TemplateErrorKind::UndefinedError || error.detail().is_some() {
         return error.to_string();
     }

--- a/hawkeye/tests/test/command.rs
+++ b/hawkeye/tests/test/command.rs
@@ -106,6 +106,34 @@ ignore = "disable"
 }
 
 #[test]
+fn template_errors_identify_the_undefined_expression() {
+    let project = Project::empty();
+    project.write(
+        "licenserc.toml",
+        r#"[header]
+builtin = "Apache-2.0"
+
+[files]
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+    );
+    project.write("main.rs", "fn main() {}\n");
+
+    let formatted = project.run(["format"]);
+    assert_exit(&formatted, 2);
+    assert!(
+        stderr(&formatted).contains(
+            "source: undefined value in template expression \"props.inception_year\" (in header:1)"
+        ),
+        "unexpected diagnostic:\n{}",
+        stderr(&formatted)
+    );
+}
+
+#[test]
 fn commands_process_requested_files_and_directories() {
     let project = Project::empty();
     project.write(

--- a/hawkeye/tests/test/command.rs
+++ b/hawkeye/tests/test/command.rs
@@ -126,7 +126,7 @@ ignore = "disable"
     assert_exit(&formatted, 2);
     assert!(
         stderr(&formatted).contains(
-            "source: undefined value in template expression \"props.inception_year\" (in header:1)"
+            "cannot render header template: undefined value in template expression \"props.inception_year\" (in header:1)"
         ),
         "unexpected diagnostic:\n{}",
         stderr(&formatted)


### PR DESCRIPTION
## Summary

- include the failing template expression in undefined-value render errors
- add a CLI regression test for built-in headers with missing props
