### PR TITLE
fix: honor gitignore without a worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Bug fixes
+
+* Honor `.gitignore` files under `files.root` when automatic Git discovery falls back outside a worktree.
+
 ## v7.0.0 (2026-08-22)
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Rules match complete filenames or case-insensitive filename suffixes. Extensions
 
 ### Git integration
 
-`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to filesystem discovery outside one. The fallback honors `.gitignore` files at and below `files.root` without reading ignore files from parent directories or the user's global Git configuration. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery without Git ignore rules.
+`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to ignore-aware filesystem discovery outside one. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery without Git ignore rules.
 
 `git.file_attrs` defaults to `disable` because resolving attributes may walk a long history for every selected path. Prefer fixed values in `props` unless the template genuinely needs repository history. `auto` populates attributes when complete history is available; `enable` requires a usable repository and complete history. Selecting paths on the command line also limits Git status and history work to those files.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Rules match complete filenames or case-insensitive filename suffixes. Extensions
 
 ### Git integration
 
-`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to filesystem discovery outside one. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery unconditionally.
+`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to filesystem discovery outside one. The fallback honors `.gitignore` files at and below `files.root` without reading ignore files from parent directories or the user's global Git configuration. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery without Git ignore rules.
 
 `git.file_attrs` defaults to `disable` because resolving attributes may walk a long history for every selected path. Prefer fixed values in `props` unless the template genuinely needs repository history. `auto` populates attributes when complete history is available; `enable` requires a usable repository and complete history. Selecting paths on the command line also limits Git status and history work to those files.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Rules match complete filenames or case-insensitive filename suffixes. Extensions
 
 ### Git integration
 
-`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to ignore-aware filesystem discovery outside one. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery without Git ignore rules.
+`git.ignore` defaults to `auto`: it uses the Git index and ignore rules inside a worktree and falls back to filesystem discovery using `.gitignore` files at or below `files.root` outside one. Tracked files remain selected even when they match an ignore rule. Set the mode to `enable` to require a worktree or `disable` to use filesystem discovery without Git ignore rules.
 
 `git.file_attrs` defaults to `disable` because resolving attributes may walk a long history for every selected path. Prefer fixed values in `props` unless the template genuinely needs repository history. `auto` populates attributes when complete history is available; `enable` requires a usable repository and complete history. Selecting paths on the command line also limits Git status and history work to those files.
 

--- a/hawkeye/src/config.rs
+++ b/hawkeye/src/config.rs
@@ -178,7 +178,7 @@ pub enum FeatureMode {
     /// Never use the feature.
     #[serde(rename = "disable")]
     Disable,
-    /// Use the feature when a Git repository is available.
+    /// Use the feature when available without requiring it.
     #[serde(rename = "auto")]
     #[default]
     Auto,

--- a/hawkeye/src/engine/discovery.rs
+++ b/hawkeye/src/engine/discovery.rs
@@ -211,29 +211,17 @@ impl Engine {
     fn walk_directory(&self, scan_root: &Path) -> Result<BTreeSet<PathBuf>, Error> {
         let use_git_ignore = self.git.ignore != FeatureMode::Disable;
         let mut files = BTreeSet::new();
-        let walk_root = if use_git_ignore {
-            &self.root
-        } else {
-            scan_root
-        };
-        let mut builder = WalkBuilder::new(walk_root);
-        builder
+        let walker = WalkBuilder::new(scan_root)
             .hidden(false)
             .ignore(false)
             .git_ignore(use_git_ignore)
-            .git_global(false)
-            .git_exclude(false)
-            .parents(false)
+            .git_global(use_git_ignore)
+            .git_exclude(use_git_ignore)
+            .parents(use_git_ignore)
             .require_git(false)
             .follow_links(false)
-            .overrides(self.walk_filter.clone());
-        if walk_root != scan_root {
-            let scan_root = scan_root.to_path_buf();
-            builder.filter_entry(move |entry| {
-                entry.path().starts_with(&scan_root) || scan_root.starts_with(entry.path())
-            });
-        }
-        let walker = builder.build();
+            .overrides(self.walk_filter.clone())
+            .build();
         for entry in walker {
             let entry = entry.map_err(|err| {
                 Error::new(ErrorKind::Unexpected, "cannot discover files").with_source(err)

--- a/hawkeye/src/engine/discovery.rs
+++ b/hawkeye/src/engine/discovery.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
+use ignore::Walk;
 use ignore::WalkBuilder;
 use ignore::overrides::Override;
 use ignore::overrides::OverrideBuilder;
@@ -209,20 +210,8 @@ impl Engine {
     }
 
     fn walk_directory(&self, scan_root: &Path) -> Result<BTreeSet<PathBuf>, Error> {
-        let use_git_ignore = self.git.ignore != FeatureMode::Disable;
         let mut files = BTreeSet::new();
-        let walker = WalkBuilder::new(scan_root)
-            .hidden(false)
-            .ignore(false)
-            .git_ignore(use_git_ignore)
-            .git_global(use_git_ignore)
-            .git_exclude(use_git_ignore)
-            .parents(use_git_ignore)
-            .require_git(false)
-            .follow_links(false)
-            .overrides(self.walk_filter.clone())
-            .build();
-        for entry in walker {
+        for entry in self.build_filesystem_walker(scan_root) {
             let entry = entry.map_err(|err| {
                 Error::new(ErrorKind::Unexpected, "cannot discover files").with_source(err)
             })?;
@@ -251,6 +240,28 @@ impl Engine {
         }
         Ok(files)
     }
+
+    fn build_filesystem_walker(&self, scan_root: &Path) -> Walk {
+        let use_git_ignore = self.git.ignore != FeatureMode::Disable;
+        let scan_root = scan_root.to_path_buf();
+        // Root the walker here so requested subdirectories inherit only in-scope .gitignore files.
+        WalkBuilder::new(&self.root)
+            .hidden(false)
+            .ignore(false)
+            .git_ignore(use_git_ignore)
+            .git_global(false)
+            .git_exclude(false)
+            .parents(false)
+            .require_git(false)
+            .follow_links(false)
+            .overrides(self.walk_filter.clone())
+            .filter_entry(move |entry| is_ancestor_or_descendant(entry.path(), &scan_root))
+            .build()
+    }
+}
+
+fn is_ancestor_or_descendant(path: &Path, reference: &Path) -> bool {
+    path.starts_with(reference) || reference.starts_with(path)
 }
 
 pub fn compile_file_filters(

--- a/hawkeye/src/engine/discovery.rs
+++ b/hawkeye/src/engine/discovery.rs
@@ -211,16 +211,29 @@ impl Engine {
     fn walk_directory(&self, scan_root: &Path) -> Result<BTreeSet<PathBuf>, Error> {
         let use_git_ignore = self.git.ignore != FeatureMode::Disable;
         let mut files = BTreeSet::new();
-        let walker = WalkBuilder::new(scan_root)
+        let walk_root = if use_git_ignore {
+            &self.root
+        } else {
+            scan_root
+        };
+        let mut builder = WalkBuilder::new(walk_root);
+        builder
             .hidden(false)
             .ignore(false)
             .git_ignore(use_git_ignore)
-            .git_global(use_git_ignore)
-            .git_exclude(use_git_ignore)
-            .parents(use_git_ignore)
+            .git_global(false)
+            .git_exclude(false)
+            .parents(false)
+            .require_git(false)
             .follow_links(false)
-            .overrides(self.walk_filter.clone())
-            .build();
+            .overrides(self.walk_filter.clone());
+        if walk_root != scan_root {
+            let scan_root = scan_root.to_path_buf();
+            builder.filter_entry(move |entry| {
+                entry.path().starts_with(&scan_root) || scan_root.starts_with(entry.path())
+            });
+        }
+        let walker = builder.build();
         for entry in walker {
             let entry = entry.map_err(|err| {
                 Error::new(ErrorKind::Unexpected, "cannot discover files").with_source(err)

--- a/hawkeye/tests/cases/mixed/.gitignore
+++ b/hawkeye/tests/cases/mixed/.gitignore
@@ -1,1 +1,1 @@
-not_ignored_without_repository.rs
+ignored_without_repository.rs

--- a/hawkeye/tests/cases/mixed/ignored_without_repository.rs
+++ b/hawkeye/tests/cases/mixed/ignored_without_repository.rs
@@ -1,0 +1,1 @@
+fn ignored_without_a_repository() {}

--- a/hawkeye/tests/cases/mixed/not_ignored_without_repository.rs
+++ b/hawkeye/tests/cases/mixed/not_ignored_without_repository.rs
@@ -1,1 +1,0 @@
-fn selected_without_a_repository() {}

--- a/hawkeye/tests/test/command.rs
+++ b/hawkeye/tests/test/command.rs
@@ -206,6 +206,40 @@ ignore = "disable"
 
 #[test]
 fn requested_directories_respect_git_ignore() {
+    for with_repository in [false, true] {
+        let project = Project::empty();
+        project.write(
+            "licenserc.toml",
+            r#"[header]
+text = "Copyright 2026 Acme"
+
+[files]
+includes = ["**/*.rs"]
+
+[git]
+ignore = "auto"
+"#,
+        );
+        project.write(".gitignore", "ignored/\n");
+        project.write("ignored/inside.rs", "fn ignored() {}\n");
+        project.write("visible/inside.rs", "fn visible() {}\n");
+        if with_repository {
+            project.git(["init", "--initial-branch=main"]);
+        }
+
+        let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
+        assert_exit(&directories, 0);
+        assert_report(&directories, &[("visible/inside.rs", "add")]);
+        assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
+
+        let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
+        assert_exit(&direct, 0);
+        assert_report(&direct, &[("ignored/inside.rs", "add")]);
+    }
+}
+
+#[test]
+fn filesystem_git_ignore_is_bounded_by_files_root() {
     let project = Project::empty();
     project.write(
         "licenserc.toml",
@@ -213,25 +247,26 @@ fn requested_directories_respect_git_ignore() {
 text = "Copyright 2026 Acme"
 
 [files]
+root = "source"
 includes = ["**/*.rs"]
 
 [git]
-ignore = "enable"
+ignore = "auto"
 "#,
     );
-    project.write(".gitignore", "ignored/\n");
-    project.write("ignored/inside.rs", "fn ignored() {}\n");
-    project.write("visible/inside.rs", "fn visible() {}\n");
-    project.git(["init", "--initial-branch=main"]);
+    project.write(".gitignore", "source/from_parent.rs\n");
+    project.write("source/.gitignore", "ignored.rs\n");
+    project.write("source/from_parent.rs", "fn from_parent() {}\n");
+    project.write("source/ignored.rs", "fn ignored() {}\n");
+    project.write("source/selected.rs", "fn selected() {}\n");
 
-    let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
-    assert_exit(&directories, 0);
-    assert_report(&directories, &[("visible/inside.rs", "add")]);
-    assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
-
-    let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
-    assert_exit(&direct, 0);
-    assert_report(&direct, &[("ignored/inside.rs", "add")]);
+    let formatted = project.run(["format", "--output-format=json"]);
+    assert_exit(&formatted, 0);
+    assert_report(
+        &formatted,
+        &[("from_parent.rs", "add"), ("selected.rs", "add")],
+    );
+    assert_eq!(project.read("source/ignored.rs"), "fn ignored() {}\n");
 }
 
 #[test]

--- a/hawkeye/tests/test/command.rs
+++ b/hawkeye/tests/test/command.rs
@@ -206,40 +206,6 @@ ignore = "disable"
 
 #[test]
 fn requested_directories_respect_git_ignore() {
-    for with_repository in [false, true] {
-        let project = Project::empty();
-        project.write(
-            "licenserc.toml",
-            r#"[header]
-text = "Copyright 2026 Acme"
-
-[files]
-includes = ["**/*.rs"]
-
-[git]
-ignore = "auto"
-"#,
-        );
-        project.write(".gitignore", "ignored/\n");
-        project.write("ignored/inside.rs", "fn ignored() {}\n");
-        project.write("visible/inside.rs", "fn visible() {}\n");
-        if with_repository {
-            project.git(["init", "--initial-branch=main"]);
-        }
-
-        let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
-        assert_exit(&directories, 0);
-        assert_report(&directories, &[("visible/inside.rs", "add")]);
-        assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
-
-        let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
-        assert_exit(&direct, 0);
-        assert_report(&direct, &[("ignored/inside.rs", "add")]);
-    }
-}
-
-#[test]
-fn filesystem_git_ignore_is_bounded_by_files_root() {
     let project = Project::empty();
     project.write(
         "licenserc.toml",
@@ -247,26 +213,25 @@ fn filesystem_git_ignore_is_bounded_by_files_root() {
 text = "Copyright 2026 Acme"
 
 [files]
-root = "source"
 includes = ["**/*.rs"]
 
 [git]
-ignore = "auto"
+ignore = "enable"
 "#,
     );
-    project.write(".gitignore", "source/from_parent.rs\n");
-    project.write("source/.gitignore", "ignored.rs\n");
-    project.write("source/from_parent.rs", "fn from_parent() {}\n");
-    project.write("source/ignored.rs", "fn ignored() {}\n");
-    project.write("source/selected.rs", "fn selected() {}\n");
+    project.write(".gitignore", "ignored/\n");
+    project.write("ignored/inside.rs", "fn ignored() {}\n");
+    project.write("visible/inside.rs", "fn visible() {}\n");
+    project.git(["init", "--initial-branch=main"]);
 
-    let formatted = project.run(["format", "--output-format=json"]);
-    assert_exit(&formatted, 0);
-    assert_report(
-        &formatted,
-        &[("from_parent.rs", "add"), ("selected.rs", "add")],
-    );
-    assert_eq!(project.read("source/ignored.rs"), "fn ignored() {}\n");
+    let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
+    assert_exit(&directories, 0);
+    assert_report(&directories, &[("visible/inside.rs", "add")]);
+    assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
+
+    let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
+    assert_exit(&direct, 0);
+    assert_report(&direct, &[("ignored/inside.rs", "add")]);
 }
 
 #[test]

--- a/hawkeye/tests/test/command.rs
+++ b/hawkeye/tests/test/command.rs
@@ -206,32 +206,38 @@ ignore = "disable"
 
 #[test]
 fn requested_directories_respect_git_ignore() {
-    let project = Project::empty();
-    project.write(
-        "licenserc.toml",
-        r#"[header]
+    for git_ignore in ["auto", "enable"] {
+        let project = Project::empty();
+        project.write(
+            "licenserc.toml",
+            format!(
+                r#"[header]
 text = "Copyright 2026 Acme"
 
 [files]
 includes = ["**/*.rs"]
 
 [git]
-ignore = "enable"
-"#,
-    );
-    project.write(".gitignore", "ignored/\n");
-    project.write("ignored/inside.rs", "fn ignored() {}\n");
-    project.write("visible/inside.rs", "fn visible() {}\n");
-    project.git(["init", "--initial-branch=main"]);
+ignore = "{git_ignore}"
+"#
+            ),
+        );
+        project.write(".gitignore", "ignored/\n");
+        project.write("ignored/inside.rs", "fn ignored() {}\n");
+        project.write("visible/inside.rs", "fn visible() {}\n");
+        if git_ignore == "enable" {
+            project.git(["init", "--initial-branch=main"]);
+        }
 
-    let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
-    assert_exit(&directories, 0);
-    assert_report(&directories, &[("visible/inside.rs", "add")]);
-    assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
+        let directories = project.run(["format", "ignored", "visible", "--output-format=json"]);
+        assert_exit(&directories, 0);
+        assert_report(&directories, &[("visible/inside.rs", "add")]);
+        assert_eq!(project.read("ignored/inside.rs"), "fn ignored() {}\n");
 
-    let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
-    assert_exit(&direct, 0);
-    assert_report(&direct, &[("ignored/inside.rs", "add")]);
+        let direct = project.run(["format", "ignored/inside.rs", "--output-format=json"]);
+        assert_exit(&direct, 0);
+        assert_report(&direct, &[("ignored/inside.rs", "add")]);
+    }
 }
 
 #[test]

--- a/hawkeye/tests/test/format.rs
+++ b/hawkeye/tests/test/format.rs
@@ -110,6 +110,64 @@ fn mixed_repository_formats_checks_and_removes_headers() {
 }
 
 #[test]
+fn filesystem_gitignore_is_bounded_to_files_root() {
+    let project = Project::empty();
+    project.write(
+        "licenserc.toml",
+        r#"[header]
+text = "Copyright 2026 Acme"
+
+[files]
+root = "source"
+includes = ["**/*.rs"]
+"#,
+    );
+    project.write(".gitignore", "source/from_parent.rs\n");
+    project.write("global-ignore", "from_global.rs\n");
+    project.write(
+        "gitconfig",
+        format!(
+            "[core]\n    excludesFile = {}\n",
+            project.path().join("global-ignore").display()
+        ),
+    );
+    project.write("source/.gitignore", "from_root.rs\nignored/\n");
+    project.write("source/from_global.rs", "fn from_global() {}\n");
+    project.write("source/from_parent.rs", "fn from_parent() {}\n");
+    project.write("source/from_root.rs", "fn from_root() {}\n");
+    project.write("source/ignored/inside.rs", "fn ignored() {}\n");
+    project.write("source/nested/.gitignore", "from_nested.rs\n");
+    project.write("source/nested/from_nested.rs", "fn from_nested() {}\n");
+    project.write("source/nested/visible.rs", "fn nested() {}\n");
+    project.write("source/visible.rs", "fn visible() {}\n");
+
+    let formatted = project
+        .command(["format", "--output-format=json"])
+        .env("GIT_CONFIG_GLOBAL", project.path().join("gitconfig"))
+        .output()
+        .expect("run hawkeye");
+    assert_exit(&formatted, 0);
+    assert_report(
+        &formatted,
+        &[
+            ("from_global.rs", "add"),
+            ("from_parent.rs", "add"),
+            ("nested/visible.rs", "add"),
+            ("visible.rs", "add"),
+        ],
+    );
+    assert_eq!(project.read("source/from_root.rs"), "fn from_root() {}\n");
+    assert_eq!(
+        project.read("source/ignored/inside.rs"),
+        "fn ignored() {}\n"
+    );
+    assert_eq!(
+        project.read("source/nested/from_nested.rs"),
+        "fn from_nested() {}\n"
+    );
+}
+
+#[test]
 fn format_preserves_preambles_and_existing_line_endings() {
     let project = Project::from_case("preambles");
     project.write("bom.cs", b"\xef\xbb\xbfpublic class Example {}\n");

--- a/hawkeye/tests/test/format.rs
+++ b/hawkeye/tests/test/format.rs
@@ -22,6 +22,7 @@ use super::support::assert_report;
 fn mixed_repository_formats_checks_and_removes_headers() {
     let project = Project::from_case("mixed");
     let before_app = project.read("app.rs");
+    let before_ignored = project.read("ignored_without_repository.rs");
     let before_makefile = project.read("Makefile");
     let before_types = project.read("types.d.ts");
 
@@ -33,7 +34,6 @@ fn mixed_repository_formats_checks_and_removes_headers() {
             ("Makefile", "add"),
             ("app.rs", "add"),
             ("legacy.rs", "replace"),
-            ("not_ignored_without_repository.rs", "add"),
             ("notes.txt", "unsupported"),
             ("types.d.ts", "add"),
         ],
@@ -47,7 +47,6 @@ fn mixed_repository_formats_checks_and_removes_headers() {
             ("Makefile", "add"),
             ("app.rs", "add"),
             ("legacy.rs", "replace"),
-            ("not_ignored_without_repository.rs", "add"),
             ("notes.txt", "unsupported"),
             ("types.d.ts", "add"),
         ],
@@ -70,7 +69,6 @@ fn mixed_repository_formats_checks_and_removes_headers() {
             ("Makefile", "clean"),
             ("app.rs", "clean"),
             ("legacy.rs", "clean"),
-            ("not_ignored_without_repository.rs", "clean"),
             ("notes.txt", "unsupported"),
             ("types.d.ts", "clean"),
         ],
@@ -84,7 +82,6 @@ fn mixed_repository_formats_checks_and_removes_headers() {
             ("Makefile", "clean"),
             ("app.rs", "clean"),
             ("legacy.rs", "clean"),
-            ("not_ignored_without_repository.rs", "clean"),
             ("notes.txt", "unsupported"),
             ("types.d.ts", "clean"),
         ],
@@ -98,12 +95,15 @@ fn mixed_repository_formats_checks_and_removes_headers() {
             ("Makefile", "remove"),
             ("app.rs", "remove"),
             ("legacy.rs", "remove"),
-            ("not_ignored_without_repository.rs", "remove"),
             ("notes.txt", "unsupported"),
             ("types.d.ts", "remove"),
         ],
     );
     assert_eq!(project.read("app.rs"), before_app);
+    assert_eq!(
+        project.read("ignored_without_repository.rs"),
+        before_ignored
+    );
     assert_eq!(project.read("Makefile"), before_makefile);
     assert_eq!(project.read("types.d.ts"), before_types);
     assert_eq!(project.read("legacy.rs"), "fn legacy() {}\n");


### PR DESCRIPTION
## Summary

- Honor `.gitignore` files at or below `files.root` when automatic Git discovery falls back outside a worktree.
- Keep fallback discovery independent of parent directories and global Git configuration.
- Make requested directories inherit the same in-scope ignore rules as a full scan.

## Design Notes

The filesystem walker starts at `files.root` to establish the ignore boundary, then prunes paths that are neither ancestors nor descendants of the requested directory. This preserves targeted traversal without reading ignore rules from outside the configured source tree.
