### PR TITLE
feat: support path templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@ Use `cargo x` as the source of truth for repository workflows.
 - Run `cargo x --help` before choosing build, test, lint, or formatting commands.
 - Run `cargo x <command> --help` for command-specific behavior.
 
+## Markdown Style
+
+- Keep each prose paragraph and list item on one source line.
+- Pad table cells with spaces to align columns in the Markdown source.
+
 ## Commits and Pull Requests
 
 Follow the semantic definition at `.github/semantic.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
-* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd`, `config_dir`, `config_path`, `env`, and a `join_path` filter. Shared configs can use `root = "{{ cwd }}"` to scan the invocation directory while relative paths remain based on the config directory.
+* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd` and `config_dir` variables. Shared configs can explicitly select the invocation directory or the config directory while existing relative paths retain their behavior.
 
 ## v7.0.1 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
-* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd`, `config_dir`, and a native `join_path` filter, so shared configs can scan the invocation directory and load headers beside the config.
+* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd` and `config_dir` variables, so shared configs can scan the invocation directory and load headers beside the config.
 
 ## v7.0.1 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
-* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd` and `config_dir` variables. Shared configs can explicitly select the invocation directory or the config directory while existing relative paths retain their behavior.
+* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd`, `config_dir`, and a native `join_path` filter, so shared configs can scan the invocation directory and load headers beside the config.
 
 ## v7.0.1 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### New features
+
+* Support MiniJinja path templates in `files.root` and `header.path`, with `cwd`, `config_dir`, `config_path`, `env`, and a `join_path` filter. Shared configs can use `root = "{{ cwd }}"` to scan the invocation directory while relative paths remain based on the config directory.
+
 ## v7.0.1 (2026-09-01)
 
 ### Bug fixes

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -92,7 +92,19 @@ Use this field mapping for the rest of the config:
 | `useDefaultExcludes` | none                              | Remove it and make required exclusions explicit.               |
 | `useDefaultMapping`  | none                              | Remove it; built-in rules are always low-priority fallbacks.   |
 
-v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the directory containing the selected config file, so rewrite the path when those directories differ. Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources.
+v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the directory containing the selected config file. To preserve v6's `baseDir = "."` behavior, use a path template:
+
+```toml
+[files]
+root = "{{ cwd }}"
+
+[header]
+path = "HEADER.txt"
+```
+
+This scans the invocation directory regardless of where the shared config is stored. For v6's `baseDir = "src"`, use `root = "{{ [cwd, 'src'] | join_path }}"`. Leaving `root` unset or setting it to `"."` keeps v7's config-directory default.
+
+Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources. Keep `path = "HEADER.txt"` for a header beside the config, or use `path = "{{ [cwd, 'HEADER.txt'] | join_path }}"` for a header in the invocation directory. See [Path templates](README.md#path-templates) for the complete context and resolution rules.
 
 ### Header source
 

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,6 +1,6 @@
 # Migrating from HawkEye v6 to v7
 
-HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and several behaviors changed in addition to the move from camel case to snake case. This guide targets v6.5.x and v7.0.0 and is written as an executable migration checklist for either a person or a code agent.
+HawkEye v7 is a rewrite. It does not accept v6 configuration aliases, and several behaviors changed in addition to the move from camel case to snake case. This guide targets v6.5.x and v7 and is written as an executable migration checklist for either a person or a code agent.
 
 ## Migration rules
 
@@ -60,7 +60,7 @@ builtin = "Apache-2.0"
 keywords = ["copyright"]
 
 [files]
-root = "."
+root = "{{ cwd }}"
 includes = ["**/*.rs", "**/*.toml"]
 excludes = ["generated/**"]
 
@@ -77,7 +77,7 @@ Use this field mapping for the rest of the config:
 
 | v6                   | v7                                | Migration action                                               |
 |----------------------|-----------------------------------|----------------------------------------------------------------|
-| `baseDir`            | `files.root`                      | Move the value under `[files]`.                                |
+| `baseDir`            | `files.root`                      | Move under `[files]`; use `cwd` for invocation-relative paths.  |
 | `inlineHeader`       | `header.text`                     | Move the template under `[header]`.                            |
 | `headerPath`         | `header.builtin` or `header.path` | Use a built-in key for a bundled header; otherwise use a path. |
 | `keywords`           | `header.keywords`                 | Move the list under `[header]`.                                |
@@ -99,12 +99,12 @@ v6 evaluated a relative `baseDir` from the process working directory. v7 resolve
 root = "{{ cwd }}"
 
 [header]
-path = "HEADER.txt"
+path = "{{ config_dir }}/HEADER.txt"
 ```
 
-This scans the invocation directory regardless of where the shared config is stored. For v6's `baseDir = "src"`, use `root = "{{ [cwd, 'src'] | join_path }}"`. Leaving `root` unset or setting it to `"."` keeps v7's config-directory default.
+This scans the invocation directory regardless of where the shared config is stored. For v6's `baseDir = "src"`, use `root = "{{ cwd }}/src"`. To scan beside the config, write `root = "{{ config_dir }}"`. Leaving `root` unset or setting it to `"."` keeps v7's config-directory default.
 
-Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources. Keep `path = "HEADER.txt"` for a header beside the config, or use `path = "{{ [cwd, 'HEADER.txt'] | join_path }}"` for a header in the invocation directory. See [Path templates](README.md#path-templates) for the complete context and resolution rules.
+Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources. Use `path = "{{ config_dir }}/HEADER.txt"` for a header beside the config, or `path = "{{ cwd }}/HEADER.txt"` for a header in the invocation directory. See [Path templates](README.md#path-templates) for the complete context and resolution rules.
 
 ### Header source
 

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -92,9 +92,9 @@ Use this field mapping for the rest of the config:
 | `useDefaultExcludes` | none                              | Remove it and make required exclusions explicit.               |
 | `useDefaultMapping`  | none                              | Remove it; built-in rules are always low-priority fallbacks.   |
 
-v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the config directory. To preserve invocation-relative scanning, use `root = "{{ cwd }}"` for v6's `baseDir = "."`, or `root = "{{ [cwd, 'src'] | join_path }}"` for `baseDir = "src"`.
+v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the config directory. To preserve invocation-relative scanning, use `root = "{{ cwd }}"` for v6's `baseDir = "."`. On Unix, use `root = "{{ cwd }}/src"` for `baseDir = "src"`.
 
-Relative `header.path` values also use only the config directory; v6 additionally tried `baseDir` and the process working directory. If a header relied on that fallback, choose its location explicitly, such as `path = "{{ [cwd, 'HEADER.txt'] | join_path }}"`. See [Path templates](README.md#path-templates) for the shared-config example and available path bases.
+Relative `header.path` values also use only the config directory; v6 additionally tried `baseDir` and the process working directory. If a header relied on that fallback, choose its location explicitly, such as `path = "{{ cwd }}/HEADER.txt"` on Unix. See [Path templates](README.md#path-templates) for shared configs and Windows-compatible path composition.
 
 ### Header source
 

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -92,19 +92,9 @@ Use this field mapping for the rest of the config:
 | `useDefaultExcludes` | none                              | Remove it and make required exclusions explicit.               |
 | `useDefaultMapping`  | none                              | Remove it; built-in rules are always low-priority fallbacks.   |
 
-v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the directory containing the selected config file. To preserve v6's `baseDir = "."` behavior, use a path template:
+v6 evaluated a relative `baseDir` from the process working directory. v7 resolves a relative `files.root` from the config directory. To preserve invocation-relative scanning, use `root = "{{ cwd }}"` for v6's `baseDir = "."`, or `root = "{{ [cwd, 'src'] | join_path }}"` for `baseDir = "src"`.
 
-```toml
-[files]
-root = "{{ cwd }}"
-
-[header]
-path = "{{ config_dir }}/HEADER.txt"
-```
-
-This scans the invocation directory regardless of where the shared config is stored. For v6's `baseDir = "src"`, use `root = "{{ cwd }}/src"`. To scan beside the config, write `root = "{{ config_dir }}"`. Leaving `root` unset or setting it to `"."` keeps v7's config-directory default.
-
-Relative `header.path` values are also resolved only from the config directory; v6 additionally tried `baseDir` and the process working directory for resources. Use `path = "{{ config_dir }}/HEADER.txt"` for a header beside the config, or `path = "{{ cwd }}/HEADER.txt"` for a header in the invocation directory. See [Path templates](README.md#path-templates) for the complete context and resolution rules.
+Relative `header.path` values also use only the config directory; v6 additionally tried `baseDir` and the process working directory. If a header relied on that fallback, choose its location explicitly, such as `path = "{{ [cwd, 'HEADER.txt'] | join_path }}"`. See [Path templates](README.md#path-templates) for the shared-config example and available path bases.
 
 ### Header source
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following example shows every configuration section. Field names are snake c
 [header]
 # Choose exactly one source. Built-in keys are case-sensitive.
 builtin = "Apache-2.0"
-# path = "{{ config_dir }}/HEADER.txt"
+# path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
 # text = "Copyright {{ props.inception_year }} {{ props.copyright_owner }}"
 
 # Every keyword must occur, case-insensitively, before an existing comment can
@@ -177,30 +177,28 @@ styles_in = ["doubleslash", "slashstar"]
 
 ### Path templates
 
-`files.root` and `header.path` accept MiniJinja templates. Choose their base explicitly with one of two variables, captured when the config is loaded:
-
-| Variable     | Meaning |
-|--------------|---------|
-| `cwd`        | The absolute process working directory, independent of the `PWD` environment variable. |
-| `config_dir` | The absolute directory containing the canonical config file, after resolving symlinks. |
-
-To share a config across projects, scan the directory where HawkEye was invoked while keeping the header beside the config:
+`files.root` and `header.path` accept MiniJinja templates. A shared config can scan the directory where HawkEye was invoked while keeping its header beside the config:
 
 ```toml
 [files]
 root = "{{ cwd }}"
 
 [header]
-path = "{{ config_dir }}/HEADER.txt"
+path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
 ```
 
-For subdirectories, write `root = "{{ cwd }}/src"` or use MiniJinja's built-in string operations, such as `root = "{{ [cwd, 'src'] | join('/') }}"`. Forward slashes are accepted as path separators on Windows too.
+The two variables are captured when the config is loaded:
 
-To scan beside the config instead, write `root = "{{ config_dir }}"`. Plain relative paths and relative template results remain based on `config_dir`; leaving `root` unset or setting it to `"."` preserves this existing default. Absolute results are used directly. Neither variable infers a project or Git root.
+| Variable     | Meaning |
+|--------------|---------|
+| `cwd`        | The absolute process working directory. |
+| `config_dir` | The absolute directory containing the config file, after resolving symlinks. |
 
-HawkEye does not expose environment variables to path templates. Templates use strict undefined values and no auto-escaping. Syntax errors, missing values, empty results, and NUL bytes fail config loading and identify the affected field. Whitespace is preserved. Referenced context values must be valid UTF-8; unused non-UTF-8 directories do not prevent loading a config.
+Use HawkEye's `join_path` filter to join a list of strings with native platform path rules. For example, `root = "{{ [cwd, 'src'] | join_path }}"` selects the invocation directory's `src` subdirectory across platforms.
 
-HawkEye parses TOML first and renders each path once. Text returned by a variable is not evaluated as another template. To use literal template delimiters in a path, wrap them in a raw block, for example `root = "{% raw %}{{ sources }}{% endraw %}"`. Header contents and other configuration fields are not rendered at this stage; `props` and `attrs` are available only when rendering a header for a file.
+Relative paths and relative template results still resolve from `config_dir`, which is also the default scan directory when `root` is omitted. Use `root = "{{ config_dir }}"` to make that choice explicit.
+
+Path templates do not expose environment variables; `props` and `attrs` are available only in header contents. Undefined variables or invalid paths fail config loading.
 
 ### Headers and templates
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following example shows every configuration section. Field names are snake c
 [header]
 # Choose exactly one source. Built-in keys are case-sensitive.
 builtin = "Apache-2.0"
-# path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
+# path = "{{ config_dir }}/HEADER.txt"
 # text = "Copyright {{ props.inception_year }} {{ props.copyright_owner }}"
 
 # Every keyword must occur, case-insensitively, before an existing comment can
@@ -177,28 +177,30 @@ styles_in = ["doubleslash", "slashstar"]
 
 ### Path templates
 
-`files.root` and `header.path` accept MiniJinja templates. A shared config can scan the directory where HawkEye was invoked while keeping its header beside the config:
+`files.root` and `header.path` accept MiniJinja templates. A shared config can scan the directory where HawkEye was invoked while keeping its header beside the config. For example, on Unix:
 
 ```toml
 [files]
 root = "{{ cwd }}"
 
 [header]
-path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
+path = "{{ config_dir }}/HEADER.txt"
 ```
 
 The two variables are captured when the config is loaded:
 
-| Variable     | Meaning |
-|--------------|---------|
-| `cwd`        | The absolute process working directory. |
+| Variable     | Meaning                                                                      |
+|--------------|------------------------------------------------------------------------------|
+| `cwd`        | The absolute process working directory.                                      |
 | `config_dir` | The absolute directory containing the config file, after resolving symlinks. |
 
-Use HawkEye's `join_path` filter to join a list of strings with native platform path rules. For example, `root = "{{ [cwd, 'src'] | join_path }}"` selects the invocation directory's `src` subdirectory across platforms.
+Subdirectories can be appended in the same way: `root = "{{ cwd }}/src"`.
 
 Relative paths and relative template results still resolve from `config_dir`, which is also the default scan directory when `root` is omitted. Use `root = "{{ config_dir }}"` to make that choice explicit.
 
 Path templates do not expose environment variables; `props` and `attrs` are available only in header contents. Undefined variables or invalid paths fail config loading.
+
+For configs that also run on Windows, use `join_path` when composing paths, for example `path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"`. This filter joins a list of strings using the platform's native path rules.
 
 ### Headers and templates
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,45 @@ style_out = "doubleslash"
 styles_in = ["doubleslash", "slashstar"]
 ```
 
+### Path templates
+
+`files.root` and `header.path` accept MiniJinja templates. Plain paths and relative template results are resolved from the directory containing the selected config file. The default `files.root = "."` uses that directory.
+
+To share a config across projects, scan the directory where HawkEye was invoked while keeping the header beside the config:
+
+```toml
+[files]
+root = "{{ cwd }}"
+
+[header]
+path = "HEADER.txt"
+```
+
+Path templates have their own context, captured when the config is loaded:
+
+| Value         | Meaning                                                                 |
+|---------------|-------------------------------------------------------------------------|
+| `cwd`         | The absolute process working directory, independent of the `PWD` environment variable. |
+| `config_dir`  | The directory containing the canonical config file, after resolving symlinks. |
+| `config_path` | The absolute, canonical config file path.                                |
+| `env`         | Environment variables, accessed as `env.NAME` or `env["NAME"]`.           |
+
+Use `join_path` to join a list of strings with the platform's path rules. For example, scan `src` below the invocation directory and load a header from an environment-selected directory:
+
+```toml
+[files]
+root = "{{ [cwd, 'src'] | join_path }}"
+
+[header]
+path = "{{ [env.POLICY_DIR, 'HEADER.txt'] | join_path }}"
+```
+
+Absolute results are used directly. Relative results, including values read from `env`, remain relative to `config_dir`. `join_path` follows native path-joining rules; a later absolute component replaces the preceding path. It does not infer a project or Git root.
+
+Templates use strict undefined values and no auto-escaping. To make an environment variable optional, write `root = "{{ env.SOURCE_ROOT | default(cwd) }}"`. Syntax errors, missing values, empty results, and NUL bytes fail config loading and identify the affected field. Whitespace is preserved. Referenced context values must be valid UTF-8; unused non-UTF-8 paths or environment values do not prevent loading a config.
+
+HawkEye parses TOML first and renders each path once. Text returned by a variable is not evaluated as another template. To use literal template delimiters in a path, wrap them in a raw block, for example `root = "{% raw %}{{ sources }}{% endraw %}"`. Header contents and other configuration fields are not rendered at this stage; `props` and `attrs` are available only when rendering a header for a file.
+
 ### Headers and templates
 
 `header.builtin` accepts `Apache-2.0`, `Apache-2.0-ASF`, or `Elastic-2.0`. `header.path` loads a UTF-8 template, while `header.text` stores the same template inline. A template file is never selected as a source file.
@@ -227,6 +266,8 @@ let report = engine.check(Scope::All)?;
 ```
 
 Each operation accepts a `Scope`. `Scope::All` processes the configured file set, while `Scope::Paths(&paths)` processes only the requested files and directories; an empty path slice processes nothing. `Engine::check` never writes files. `Engine::format` and `Engine::remove` return pending `Edits`; call `Edits::apply` to write them or `Edits::into_report` to inspect the result without writing.
+
+`Config::load` resolves path templates once. `Engine::new` uses the resulting paths without rendering them again; paths in a programmatically constructed `Config` are used as supplied.
 
 The default `application` feature builds the command-line tool. Library-only users can omit its command-specific dependencies:
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following example shows every configuration section. Field names are snake c
 [header]
 # Choose exactly one source. Built-in keys are case-sensitive.
 builtin = "Apache-2.0"
-# path = "HEADER.txt"
+# path = "{{ config_dir }}/HEADER.txt"
 # text = "Copyright {{ props.inception_year }} {{ props.copyright_owner }}"
 
 # Every keyword must occur, case-insensitively, before an existing comment can
@@ -136,8 +136,8 @@ builtin = "Apache-2.0"
 keywords = ["copyright"]
 
 [files]
-# Relative paths are resolved from the directory containing this config file.
-root = "."
+# Scan the directory containing this config file.
+root = "{{ config_dir }}"
 # An empty includes list selects every discovered file.
 includes = ["**/*.rs", "**/*.toml"]
 excludes = ["generated/**"]
@@ -177,7 +177,12 @@ styles_in = ["doubleslash", "slashstar"]
 
 ### Path templates
 
-`files.root` and `header.path` accept MiniJinja templates. Plain paths and relative template results are resolved from the directory containing the selected config file. The default `files.root = "."` uses that directory.
+`files.root` and `header.path` accept MiniJinja templates. Choose their base explicitly with one of two variables, captured when the config is loaded:
+
+| Variable     | Meaning |
+|--------------|---------|
+| `cwd`        | The absolute process working directory, independent of the `PWD` environment variable. |
+| `config_dir` | The absolute directory containing the canonical config file, after resolving symlinks. |
 
 To share a config across projects, scan the directory where HawkEye was invoked while keeping the header beside the config:
 
@@ -186,31 +191,14 @@ To share a config across projects, scan the directory where HawkEye was invoked 
 root = "{{ cwd }}"
 
 [header]
-path = "HEADER.txt"
+path = "{{ config_dir }}/HEADER.txt"
 ```
 
-Path templates have their own context, captured when the config is loaded:
+For subdirectories, write `root = "{{ cwd }}/src"` or use MiniJinja's built-in string operations, such as `root = "{{ [cwd, 'src'] | join('/') }}"`. Forward slashes are accepted as path separators on Windows too.
 
-| Value         | Meaning                                                                 |
-|---------------|-------------------------------------------------------------------------|
-| `cwd`         | The absolute process working directory, independent of the `PWD` environment variable. |
-| `config_dir`  | The directory containing the canonical config file, after resolving symlinks. |
-| `config_path` | The absolute, canonical config file path.                                |
-| `env`         | Environment variables, accessed as `env.NAME` or `env["NAME"]`.           |
+To scan beside the config instead, write `root = "{{ config_dir }}"`. Plain relative paths and relative template results remain based on `config_dir`; leaving `root` unset or setting it to `"."` preserves this existing default. Absolute results are used directly. Neither variable infers a project or Git root.
 
-Use `join_path` to join a list of strings with the platform's path rules. For example, scan `src` below the invocation directory and load a header from an environment-selected directory:
-
-```toml
-[files]
-root = "{{ [cwd, 'src'] | join_path }}"
-
-[header]
-path = "{{ [env.POLICY_DIR, 'HEADER.txt'] | join_path }}"
-```
-
-Absolute results are used directly. Relative results, including values read from `env`, remain relative to `config_dir`. `join_path` follows native path-joining rules; a later absolute component replaces the preceding path. It does not infer a project or Git root.
-
-Templates use strict undefined values and no auto-escaping. To make an environment variable optional, write `root = "{{ env.SOURCE_ROOT | default(cwd) }}"`. Syntax errors, missing values, empty results, and NUL bytes fail config loading and identify the affected field. Whitespace is preserved. Referenced context values must be valid UTF-8; unused non-UTF-8 paths or environment values do not prevent loading a config.
+HawkEye does not expose environment variables to path templates. Templates use strict undefined values and no auto-escaping. Syntax errors, missing values, empty results, and NUL bytes fail config loading and identify the affected field. Whitespace is preserved. Referenced context values must be valid UTF-8; unused non-UTF-8 directories do not prevent loading a config.
 
 HawkEye parses TOML first and renders each path once. Text returned by a variable is not evaluated as another template. To use literal template delimiters in a path, wrap them in a raw block, for example `root = "{% raw %}{{ sources }}{% endraw %}"`. Header contents and other configuration fields are not rendered at this stage; `props` and `attrs` are available only when rendering a header for a file.
 

--- a/hawkeye/src/config.rs
+++ b/hawkeye/src/config.rs
@@ -53,22 +53,15 @@ pub struct Config {
 }
 
 impl Config {
-    /// Loads a config file, renders path templates, and resolves relative paths from its directory.
+    /// Loads a TOML config file, rendering path templates and resolving relative paths
+    /// from the config directory.
     ///
-    /// `files.root` and `header.path` are rendered once with MiniJinja. Their context contains
-    /// `cwd` (the absolute process working directory at load time) and `config_dir` (the
-    /// directory containing the canonical config file). Paths can be composed with standard
-    /// MiniJinja syntax, for example `{{ cwd }}/src`. Forward slashes are accepted on Windows.
-    /// Relative results are resolved from `config_dir`. Undefined values, invalid UTF-8 in
-    /// referenced context values, empty paths, and NUL bytes are errors. Header contents are
-    /// rendered later by the engine with a separate context.
-    ///
-    /// This method parses the file without performing semantic validation. Call [`Self::validate`]
-    /// to validate it directly, or pass it to [`Engine::new`](crate::Engine::new).
+    /// For semantic validation, call [`Self::validate`] or pass the result to
+    /// [`Engine::new`](crate::Engine::new).
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read, parsed, or resolved, or a path template fails.
+    /// Returns an error if reading, parsing, or resolving the configuration fails.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let path = path.as_ref();
         let source = fs::read_to_string(path).map_err(|err| {

--- a/hawkeye/src/config.rs
+++ b/hawkeye/src/config.rs
@@ -128,8 +128,10 @@ impl Config {
 pub struct HeaderConfig {
     /// The built-in template key, when using a bundled header.
     pub builtin: Option<String>,
-    /// The template file. [`Config::load`] renders path templates and resolves relative paths
-    /// from the config directory.
+    /// The template file.
+    ///
+    /// [`Config::load`] renders path templates and resolves relative paths from the config
+    /// directory.
     pub path: Option<PathBuf>,
     /// The inline template, when the header is stored in the config file.
     pub text: Option<String>,
@@ -146,8 +148,10 @@ fn default_keywords() -> Vec<String> {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct FilesConfig {
-    /// The directory to scan; defaults to `.`. [`Config::load`] renders path templates and
-    /// resolves relative paths from the config directory.
+    /// The directory to scan; defaults to `.`.
+    ///
+    /// [`Config::load`] renders path templates and resolves relative paths from the config
+    /// directory.
     pub root: PathBuf,
     /// Git-ignore-style inclusion patterns; an empty list selects all files.
     pub includes: Vec<String>,

--- a/hawkeye/src/config.rs
+++ b/hawkeye/src/config.rs
@@ -56,12 +56,12 @@ impl Config {
     /// Loads a config file, renders path templates, and resolves relative paths from its directory.
     ///
     /// `files.root` and `header.path` are rendered once with MiniJinja. Their context contains
-    /// `cwd` (the process working directory at load time), `config_path` (the canonical config
-    /// file path), `config_dir` (its parent), and `env` (the environment at load time). The
-    /// `join_path` filter joins a list of strings using the platform's path rules. Relative
-    /// results are resolved from `config_dir`. Undefined values, invalid UTF-8 in referenced
-    /// context values, empty paths, and NUL bytes are errors. Header contents are rendered later
-    /// by the engine with a separate context.
+    /// `cwd` (the absolute process working directory at load time) and `config_dir` (the
+    /// directory containing the canonical config file). Paths can be composed with standard
+    /// MiniJinja syntax, for example `{{ cwd }}/src`. Forward slashes are accepted on Windows.
+    /// Relative results are resolved from `config_dir`. Undefined values, invalid UTF-8 in
+    /// referenced context values, empty paths, and NUL bytes are errors. Header contents are
+    /// rendered later by the engine with a separate context.
     ///
     /// This method parses the file without performing semantic validation. Call [`Self::validate`]
     /// to validate it directly, or pass it to [`Engine::new`](crate::Engine::new).

--- a/hawkeye/src/config.rs
+++ b/hawkeye/src/config.rs
@@ -14,8 +14,8 @@
 
 //! HawkEye configuration types.
 //!
-//! [`Config::load`] parses TOML and resolves relative paths. [`Config::validate`] checks
-//! relationships between the parsed fields.
+//! [`Config::load`] parses TOML, renders path templates, and resolves relative paths.
+//! [`Config::validate`] checks relationships between the parsed fields.
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -27,6 +27,7 @@ use serde::Deserialize;
 
 use crate::Error;
 use crate::ErrorKind;
+use crate::template::PathTemplates;
 
 /// Configuration for a HawkEye engine.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -52,14 +53,22 @@ pub struct Config {
 }
 
 impl Config {
-    /// Loads a config file and resolves relative paths from its directory.
+    /// Loads a config file, renders path templates, and resolves relative paths from its directory.
+    ///
+    /// `files.root` and `header.path` are rendered once with MiniJinja. Their context contains
+    /// `cwd` (the process working directory at load time), `config_path` (the canonical config
+    /// file path), `config_dir` (its parent), and `env` (the environment at load time). The
+    /// `join_path` filter joins a list of strings using the platform's path rules. Relative
+    /// results are resolved from `config_dir`. Undefined values, invalid UTF-8 in referenced
+    /// context values, empty paths, and NUL bytes are errors. Header contents are rendered later
+    /// by the engine with a separate context.
     ///
     /// This method parses the file without performing semantic validation. Call [`Self::validate`]
     /// to validate it directly, or pass it to [`Engine::new`](crate::Engine::new).
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read, parsed, or resolved.
+    /// Returns an error if the file cannot be read, parsed, or resolved, or a path template fails.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let path = path.as_ref();
         let source = fs::read_to_string(path).map_err(|err| {
@@ -83,20 +92,10 @@ impl Config {
             )
             .with_source(err)
         })?;
-        let directory = path.parent().ok_or_else(|| {
-            Error::new(
-                ErrorKind::ConfigInvalid,
-                "config file has no parent directory",
-            )
-        })?;
-
-        if config.files.root.is_relative() {
-            config.files.root = directory.join(&config.files.root);
-        }
-        if let Some(header_path) = &mut config.header.path
-            && header_path.is_relative()
-        {
-            *header_path = directory.join(&*header_path);
+        let templates = PathTemplates::new(&path)?;
+        config.files.root = templates.resolve("files.root", &config.files.root)?;
+        if let Some(header_path) = &mut config.header.path {
+            *header_path = templates.resolve("header.path", header_path)?;
         }
         Ok(config)
     }
@@ -136,7 +135,8 @@ impl Config {
 pub struct HeaderConfig {
     /// The built-in template key, when using a bundled header.
     pub builtin: Option<String>,
-    /// The template file, resolved from the config file by [`Config::load`] when relative.
+    /// The template file. [`Config::load`] renders path templates and resolves relative paths
+    /// from the config directory.
     pub path: Option<PathBuf>,
     /// The inline template, when the header is stored in the config file.
     pub text: Option<String>,
@@ -153,8 +153,8 @@ fn default_keywords() -> Vec<String> {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct FilesConfig {
-    /// The directory to scan, resolved from the config file by [`Config::load`] when relative;
-    /// defaults to `.`.
+    /// The directory to scan; defaults to `.`. [`Config::load`] renders path templates and
+    /// resolves relative paths from the config directory.
     pub root: PathBuf,
     /// Git-ignore-style inclusion patterns; an empty list selects all files.
     pub includes: Vec<String>,

--- a/hawkeye/src/template.rs
+++ b/hawkeye/src/template.rs
@@ -44,6 +44,7 @@ impl<'a> PathTemplates<'a> {
         })?;
         let mut environment = template_environment();
         environment.set_keep_trailing_newline(true);
+        environment.add_filter("join_path", join_path);
         environment.add_global(
             "config_dir",
             native_string("config_dir", directory.as_os_str()),
@@ -96,14 +97,22 @@ impl<'a> PathTemplates<'a> {
                 format!("{field} template rendered a NUL byte"),
             ));
         }
-        // Canonical Windows paths use verbatim prefixes. Normalize template separators,
-        // then rebuild components so `.` and `..` follow native path-joining rules.
-        #[cfg(windows)]
-        let rendered: PathBuf = Path::new(&rendered.replace('/', "\\"))
-            .components()
-            .collect();
         Ok(self.directory.join(rendered))
     }
+}
+
+fn join_path(parts: Vec<Value>) -> Result<String, minijinja::Error> {
+    parts
+        .iter()
+        .map(Value::as_str)
+        .collect::<Option<PathBuf>>()
+        .ok_or_else(|| {
+            minijinja::Error::new(
+                TemplateErrorKind::InvalidOperation,
+                "join_path expects a list of strings",
+            )
+        })
+        .map(|path| path.to_string_lossy().into_owned())
 }
 
 fn native_string(name: &str, value: &OsStr) -> Value {

--- a/hawkeye/src/template.rs
+++ b/hawkeye/src/template.rs
@@ -44,14 +44,9 @@ impl<'a> PathTemplates<'a> {
         })?;
         let mut environment = template_environment();
         environment.set_keep_trailing_newline(true);
-        environment.add_filter("join_path", join_path);
         environment.add_global(
             "config_dir",
             native_string("config_dir", directory.as_os_str()),
-        );
-        environment.add_global(
-            "config_path",
-            native_string("config_path", config_path.as_os_str()),
         );
         environment.add_global(
             "cwd",
@@ -65,16 +60,6 @@ impl<'a> PathTemplates<'a> {
                     .with_source(err),
                 ),
             },
-        );
-        environment.add_global(
-            "env",
-            env::vars_os()
-                .filter_map(|(name, value)| {
-                    let name = name.into_string().ok()?;
-                    let value = native_string(&format!("env.{name}"), &value);
-                    Some((name, value))
-                })
-                .collect::<Value>(),
         );
         Ok(Self {
             environment,
@@ -111,6 +96,12 @@ impl<'a> PathTemplates<'a> {
                 format!("{field} template rendered a NUL byte"),
             ));
         }
+        // Canonical Windows paths use verbatim prefixes. Normalize template separators,
+        // then rebuild components so `.` and `..` follow native path-joining rules.
+        #[cfg(windows)]
+        let rendered: PathBuf = Path::new(&rendered.replace('/', "\\"))
+            .components()
+            .collect();
         Ok(self.directory.join(rendered))
     }
 }
@@ -124,23 +115,6 @@ fn native_string(name: &str, value: &OsStr) -> Value {
             format!("path template variable {name:?} is not valid UTF-8"),
         )),
     }
-}
-
-fn join_path(parts: Vec<Value>) -> Result<String, minijinja::Error> {
-    let mut path = PathBuf::new();
-    for part in parts {
-        let part = part.as_str().ok_or_else(|| {
-            minijinja::Error::new(
-                TemplateErrorKind::InvalidOperation,
-                "join_path expects a list of strings",
-            )
-        })?;
-        path.push(part);
-    }
-    Ok(path
-        .into_os_string()
-        .into_string()
-        .expect("joining UTF-8 paths preserves UTF-8"))
 }
 
 pub struct HeaderTemplate {

--- a/hawkeye/src/template.rs
+++ b/hawkeye/src/template.rs
@@ -14,15 +14,134 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::env;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
 
 use minijinja::AutoEscape;
 use minijinja::Environment;
 use minijinja::ErrorKind as TemplateErrorKind;
 use minijinja::UndefinedBehavior;
+use minijinja::Value;
 
 use crate::Error;
 use crate::ErrorKind;
 use crate::engine::FileAttrs;
+
+pub struct PathTemplates<'a> {
+    environment: Environment<'static>,
+    directory: &'a Path,
+}
+
+impl<'a> PathTemplates<'a> {
+    pub fn new(config_path: &'a Path) -> Result<Self, Error> {
+        let directory = config_path.parent().ok_or_else(|| {
+            Error::new(
+                ErrorKind::ConfigInvalid,
+                "config file has no parent directory",
+            )
+        })?;
+        let mut environment = template_environment();
+        environment.set_keep_trailing_newline(true);
+        environment.add_filter("join_path", join_path);
+        environment.add_global(
+            "config_dir",
+            native_string("config_dir", directory.as_os_str()),
+        );
+        environment.add_global(
+            "config_path",
+            native_string("config_path", config_path.as_os_str()),
+        );
+        environment.add_global(
+            "cwd",
+            match env::current_dir() {
+                Ok(path) => native_string("cwd", path.as_os_str()),
+                Err(err) => Value::from(
+                    minijinja::Error::new(
+                        TemplateErrorKind::InvalidOperation,
+                        "cannot determine cwd",
+                    )
+                    .with_source(err),
+                ),
+            },
+        );
+        environment.add_global(
+            "env",
+            env::vars_os()
+                .filter_map(|(name, value)| {
+                    let name = name.into_string().ok()?;
+                    let value = native_string(&format!("env.{name}"), &value);
+                    Some((name, value))
+                })
+                .collect::<Value>(),
+        );
+        Ok(Self {
+            environment,
+            directory,
+        })
+    }
+
+    pub fn resolve(&self, field: &str, path: &Path) -> Result<PathBuf, Error> {
+        let source = path.to_str().ok_or_else(|| {
+            Error::new(
+                ErrorKind::ConfigInvalid,
+                format!("{field} template is not valid UTF-8"),
+            )
+        })?;
+        let rendered = self
+            .environment
+            .render_named_str(field, source, ())
+            .map_err(|err| {
+                let detail = render_error_message(&err, source);
+                Error::new(
+                    ErrorKind::ConfigInvalid,
+                    format!("cannot render {field} template: {detail}"),
+                )
+            })?;
+        if rendered.is_empty() {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                format!("{field} template rendered an empty path"),
+            ));
+        }
+        if rendered.contains('\0') {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                format!("{field} template rendered a NUL byte"),
+            ));
+        }
+        Ok(self.directory.join(rendered))
+    }
+}
+
+fn native_string(name: &str, value: &OsStr) -> Value {
+    match value.to_str() {
+        Some(value) => Value::from(value),
+        // Defer the error until lookup so unused non-UTF-8 values do not prevent loading a config.
+        None => Value::from(minijinja::Error::new(
+            TemplateErrorKind::InvalidOperation,
+            format!("path template variable {name:?} is not valid UTF-8"),
+        )),
+    }
+}
+
+fn join_path(parts: Vec<Value>) -> Result<String, minijinja::Error> {
+    let mut path = PathBuf::new();
+    for part in parts {
+        let part = part.as_str().ok_or_else(|| {
+            minijinja::Error::new(
+                TemplateErrorKind::InvalidOperation,
+                "join_path expects a list of strings",
+            )
+        })?;
+        path.push(part);
+    }
+    Ok(path
+        .into_os_string()
+        .into_string()
+        .expect("joining UTF-8 paths preserves UTF-8"))
+}
 
 pub struct HeaderTemplate {
     environment: Environment<'static>,
@@ -30,9 +149,7 @@ pub struct HeaderTemplate {
 
 impl HeaderTemplate {
     pub fn new<S: Into<Cow<'static, str>>>(source: S) -> Result<Self, Error> {
-        let mut environment = Environment::new();
-        environment.set_undefined_behavior(UndefinedBehavior::Strict);
-        environment.set_auto_escape_callback(|_| AutoEscape::None);
+        let mut environment = template_environment();
         environment
             .add_template_owned("header", source)
             .map_err(|err| {
@@ -73,6 +190,13 @@ impl HeaderTemplate {
         }
         Ok(normalized)
     }
+}
+
+fn template_environment() -> Environment<'static> {
+    let mut environment = Environment::new();
+    environment.set_undefined_behavior(UndefinedBehavior::Strict);
+    environment.set_auto_escape_callback(|_| AutoEscape::None);
+    environment
 }
 
 fn render_error_message(error: &minijinja::Error, template_source: &str) -> String {

--- a/hawkeye/tests/test.rs
+++ b/hawkeye/tests/test.rs
@@ -20,5 +20,7 @@ mod config;
 mod format;
 #[path = "test/git.rs"]
 mod git;
+#[path = "test/paths.rs"]
+mod paths;
 #[path = "test/support.rs"]
 mod support;

--- a/hawkeye/tests/test/paths.rs
+++ b/hawkeye/tests/test/paths.rs
@@ -32,7 +32,7 @@ fn shared_configs_use_cwd_independently_of_their_location() {
         project.write(
             &config_path,
             r#"[header]
-path = "HEADER.txt"
+path = "{{ config_dir }}/HEADER.txt"
 
 [files]
 root = "{{ cwd }}"
@@ -73,7 +73,12 @@ ignore = "disable"
 #[test]
 fn defaults_and_relative_results_use_the_config_directory() {
     let project = Project::empty();
-    for root in ["", "root = '.'", "root = \"{{ '.' }}\""] {
+    for root in [
+        "",
+        "root = '.'",
+        "root = \"{{ '.' }}\"",
+        "root = \"{{ config_dir }}\"",
+    ] {
         project.write(
             "config/licenserc.toml",
             format!("[header]\npath = 'HEADER.txt'\n[files]\n{root}\n"),
@@ -92,96 +97,81 @@ fn defaults_and_relative_results_use_the_config_directory() {
 }
 
 #[test]
-fn config_path_and_config_directory_are_absolute_template_values() {
+fn config_directory_supports_relative_components_and_standard_template_joins() {
     let project = Project::empty();
-    project.write(
-        "config/licenserc.toml",
-        r#"[header]
-path = "{{ config_path }}.header"
-
-[files]
-root = "{{ [config_dir, 'source'] | join_path }}"
-includes = ["**/*.rs"]
-
-[git]
-ignore = "disable"
-"#,
-    );
-    project.write("config/licenserc.toml.header", "Copyright Acme");
-    project.write("config/source/main.rs", "fn main() {}\n");
-    project.write("source/outside.rs", "fn outside() {}\n");
-
-    let checked = project.run([
-        "--config",
-        "config/licenserc.toml",
-        "check",
-        "--output-format=json",
-    ]);
-    assert_exit(&checked, 1);
-    assert_report(&checked, &[("main.rs", "add")]);
-}
-
-#[test]
-fn environment_paths_are_rendered_once_before_relative_resolution() {
-    let project = Project::empty();
-    let headers = Project::empty();
-    project.write(
-        "config/licenserc.toml",
-        r#"[header]
-path = "{{ env.HAWKEYE_TEST_HEADER }}"
-
-[files]
-root = "{{ env.HAWKEYE_TEST_ROOT | default(cwd) }}"
-includes = ["**/*.rs"]
-
-[git]
-ignore = "disable"
-"#,
-    );
-    headers.write("HEADER.txt", "Copyright {{ attrs.filename }}");
-    let directory = "source & 'quoted' {{ literal }}";
-    project.write(format!("config/{directory}/main.rs"), "fn main() {}\n");
-
+    project.write("config/HEADER.txt", "Copyright Acme");
+    project.write("source/main.rs", "fn main() {}\n");
+    project.write("config/source/outside.rs", "fn outside() {}\n");
     for root in [
-        directory.into(),
-        project
-            .path()
-            .join("config")
-            .join(directory)
-            .into_os_string(),
+        "{{ config_dir }}/../source",
+        "{{ [config_dir, '..', 'source'] | join('/') }}",
     ] {
-        let formatted = project
-            .command([
-                "--config",
-                "config/licenserc.toml",
-                "format",
-                "--dry-run",
-                "--output-format=json",
-            ])
-            .env("HAWKEYE_TEST_ROOT", root)
-            .env("HAWKEYE_TEST_HEADER", headers.path().join("HEADER.txt"))
-            .output()
-            .expect("render relative or absolute environment paths");
-        assert_exit(&formatted, 0);
-        assert_report(&formatted, &[("main.rs", "add")]);
-    }
+        project.write(
+            "config/licenserc.toml",
+            format!(
+                r#"[header]
+path = "{{{{ config_dir }}}}/./HEADER.txt"
 
-    let fallback = project
-        .command([
+[files]
+root = "{root}"
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+            ),
+        );
+
+        let checked = project.run([
             "--config",
             "config/licenserc.toml",
             "check",
             "--output-format=json",
-        ])
-        .env_remove("HAWKEYE_TEST_ROOT")
-        .env("HAWKEYE_TEST_HEADER", headers.path().join("HEADER.txt"))
-        .output()
-        .expect("use cwd when an optional environment variable is absent");
-    assert_exit(&fallback, 1);
-    assert_report(
-        &fallback,
-        &[(&format!("config/{directory}/main.rs"), "add")],
+        ]);
+        assert_exit(&checked, 1);
+        assert_report(&checked, &[("main.rs", "add")]);
+    }
+}
+
+#[test]
+fn context_paths_are_rendered_once_without_escaping() {
+    let project = Project::empty();
+    let directory = "source & 'quoted' {{ literal }}";
+    project.write(
+        format!("{directory}/HEADER.txt"),
+        "Copyright {{ attrs.filename }}",
     );
+    project.write(format!("{directory}/main.rs"), "fn main() {}\n");
+    for root in ["{{ cwd }}", "{{ config_dir }}"] {
+        project.write(
+            format!("{directory}/licenserc.toml"),
+            format!(
+                r#"[header]
+path = "{{{{ config_dir }}}}/HEADER.txt"
+
+[files]
+root = "{root}"
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+            ),
+        );
+        let formatted = project
+            .command([
+                "--config",
+                "licenserc.toml",
+                "format",
+                "--dry-run",
+                "--output-format=json",
+            ])
+            .current_dir(project.path().join(directory))
+            .output()
+            .expect("preserve template delimiters and special characters in context paths");
+        assert_exit(&formatted, 0);
+        assert_report(&formatted, &[("main.rs", "add")]);
+    }
 }
 
 #[test]
@@ -191,10 +181,10 @@ fn templated_roots_control_git_discovery_and_requested_paths() {
     policy.write(
         "licenserc.toml",
         r#"[header]
-path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
+path = "{{ config_dir }}/HEADER.txt"
 
 [files]
-root = "{{ [cwd, 'source'] | join_path }}"
+root = "{{ cwd }}/source"
 includes = ["**/*.rs"]
 excludes = ["generated/**"]
 
@@ -291,10 +281,6 @@ fn path_template_errors_identify_the_field_and_failing_expression() {
         ("", "empty path"),
         ("{{ '' }}", "empty path"),
         ("{{ '\0' }}", "NUL byte"),
-        (
-            "{{ ['source', 42] | join_path }}",
-            "join_path expects a list of strings",
-        ),
     ] {
         for field in ["files.root", "header.path"] {
             let quoted = toml::Value::String(expression.to_owned());
@@ -311,23 +297,26 @@ fn path_template_errors_identify_the_field_and_failing_expression() {
             assert!(err.to_string().contains(diagnostic), "{err}");
         }
     }
+}
 
+#[test]
+fn path_templates_do_not_expose_environment_variables() {
+    let project = Project::empty();
     project.write(
         "licenserc.toml",
-        "[header]\npath = '{{ env.HAWKEYE_TEST_HEADER }}'\n",
+        "[header]\npath = '{{ env.HAWKEYE_TEST_SECRET }}'\n",
     );
+    let secret = "test-value-must-stay-private";
     let checked = project
         .command(["check"])
-        .env_remove("HAWKEYE_TEST_HEADER")
+        .env("HAWKEYE_TEST_SECRET", secret)
         .output()
-        .expect("report a missing environment variable");
+        .expect("reject environment access in a path template");
     assert_exit(&checked, 2);
     let diagnostic = stderr(&checked);
     assert!(diagnostic.contains("header.path"), "{diagnostic}");
-    assert!(
-        diagnostic.contains("env.HAWKEYE_TEST_HEADER"),
-        "{diagnostic}"
-    );
+    assert!(diagnostic.contains("undefined value"), "{diagnostic}");
+    assert!(!diagnostic.contains(secret), "{diagnostic}");
 }
 
 #[cfg(target_os = "linux")]
@@ -338,24 +327,15 @@ fn non_utf8_context_values_fail_only_when_referenced() {
 
     let project = Project::named(OsString::from_vec(b"project-\xff".to_vec()));
     project.write("source/main.rs", "fn main() {}\n");
-    let invalid = OsString::from_vec(b"source-\xff".to_vec());
-    for root in [
-        "source",
-        "{{ 'source' }}",
-        "{{ cwd }}",
-        "{{ config_dir }}",
-        "{{ config_path }}",
-        "{{ env.HAWKEYE_TEST_ROOT }}",
-    ] {
+    for root in ["source", "{{ 'source' }}", "{{ cwd }}", "{{ config_dir }}"] {
         project.write(
             "licenserc.toml",
             format!("[header]\ntext = 'Copyright'\n[files]\nroot = {}\nincludes = ['**/*.rs']\n[git]\nignore = 'disable'\n", toml::Value::String(root.to_owned())),
         );
         let checked = project
             .command(["check", "--output-format=json"])
-            .env("HAWKEYE_TEST_ROOT", &invalid)
             .output()
-            .expect("load config with non-UTF-8 native paths and environment values");
+            .expect("load config with non-UTF-8 native paths");
         if root == "source" || root == "{{ 'source' }}" {
             assert_exit(&checked, 1);
             assert_report(&checked, &[("main.rs", "add")]);

--- a/hawkeye/tests/test/paths.rs
+++ b/hawkeye/tests/test/paths.rs
@@ -32,7 +32,7 @@ fn shared_configs_use_cwd_independently_of_their_location() {
         project.write(
             &config_path,
             r#"[header]
-path = "{{ config_dir }}/HEADER.txt"
+path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
 
 [files]
 root = "{{ cwd }}"
@@ -97,40 +97,33 @@ fn defaults_and_relative_results_use_the_config_directory() {
 }
 
 #[test]
-fn config_directory_supports_relative_components_and_standard_template_joins() {
+fn join_path_resolves_relative_components_from_the_config_directory() {
     let project = Project::empty();
     project.write("config/HEADER.txt", "Copyright Acme");
     project.write("source/main.rs", "fn main() {}\n");
     project.write("config/source/outside.rs", "fn outside() {}\n");
-    for root in [
-        "{{ config_dir }}/../source",
-        "{{ [config_dir, '..', 'source'] | join('/') }}",
-    ] {
-        project.write(
-            "config/licenserc.toml",
-            format!(
-                r#"[header]
-path = "{{{{ config_dir }}}}/./HEADER.txt"
+    project.write(
+        "config/licenserc.toml",
+        r#"[header]
+path = "{{ [config_dir, '.', 'HEADER.txt'] | join_path }}"
 
 [files]
-root = "{root}"
+root = "{{ [config_dir, '..', 'source'] | join_path }}"
 includes = ["**/*.rs"]
 
 [git]
 ignore = "disable"
 "#,
-            ),
-        );
+    );
 
-        let checked = project.run([
-            "--config",
-            "config/licenserc.toml",
-            "check",
-            "--output-format=json",
-        ]);
-        assert_exit(&checked, 1);
-        assert_report(&checked, &[("main.rs", "add")]);
-    }
+    let checked = project.run([
+        "--config",
+        "config/licenserc.toml",
+        "check",
+        "--output-format=json",
+    ]);
+    assert_exit(&checked, 1);
+    assert_report(&checked, &[("main.rs", "add")]);
 }
 
 #[test]
@@ -147,7 +140,7 @@ fn context_paths_are_rendered_once_without_escaping() {
             format!("{directory}/licenserc.toml"),
             format!(
                 r#"[header]
-path = "{{{{ config_dir }}}}/HEADER.txt"
+path = "{{{{ [config_dir, 'HEADER.txt'] | join_path }}}}"
 
 [files]
 root = "{root}"
@@ -181,10 +174,10 @@ fn templated_roots_control_git_discovery_and_requested_paths() {
     policy.write(
         "licenserc.toml",
         r#"[header]
-path = "{{ config_dir }}/HEADER.txt"
+path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
 
 [files]
-root = "{{ cwd }}/source"
+root = "{{ [cwd, 'source'] | join_path }}"
 includes = ["**/*.rs"]
 excludes = ["generated/**"]
 
@@ -281,6 +274,10 @@ fn path_template_errors_identify_the_field_and_failing_expression() {
         ("", "empty path"),
         ("{{ '' }}", "empty path"),
         ("{{ '\0' }}", "NUL byte"),
+        (
+            "{{ ['source', 42] | join_path }}",
+            "join_path expects a list of strings",
+        ),
     ] {
         for field in ["files.root", "header.path"] {
             let quoted = toml::Value::String(expression.to_owned());
@@ -317,6 +314,105 @@ fn path_templates_do_not_expose_environment_variables() {
     assert!(diagnostic.contains("header.path"), "{diagnostic}");
     assert!(diagnostic.contains("undefined value"), "{diagnostic}");
     assert!(!diagnostic.contains(secret), "{diagnostic}");
+}
+
+#[cfg(windows)]
+#[test]
+fn join_path_supports_windows_unc_paths() {
+    let project = Project::empty();
+    for (base, expected) in [
+        (r"\\server\share\policy", r"\\server\share\policy\..\source"),
+        (
+            r"\\?\UNC\server\share\policy",
+            r"\\?\UNC\server\share\source",
+        ),
+    ] {
+        let expression = format!(
+            "{{{{ [{}, '..', 'source'] | join_path }}}}",
+            serde_json::to_string(base).unwrap(),
+        );
+        project.write(
+            "licenserc.toml",
+            format!(
+                "[header]\ntext = 'Copyright'\n[files]\nroot = {}\n",
+                toml::Value::String(expression),
+            ),
+        );
+        let config = Config::load(project.path().join("licenserc.toml"))
+            .expect("resolve a UNC path without accessing the network share");
+        assert_eq!(config.files.root, std::path::Path::new(expected));
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn path_templates_preserve_windows_stream_paths() {
+    let project = Project::empty();
+    for expression in [
+        r"\\?\C:\policy\headers\H:license",
+        r#"{{ ["\\\\?\\C:\\policy", "headers/H:license"] | join_path }}"#,
+    ] {
+        project.write(
+            "licenserc.toml",
+            format!(
+                "[header]\npath = {}\n",
+                toml::Value::String(expression.into())
+            ),
+        );
+        let config = Config::load(project.path().join("licenserc.toml"))
+            .expect("preserve a named stream without reinterpreting its name as a drive prefix");
+        assert_eq!(
+            config.header.path.unwrap(),
+            std::path::Path::new(r"\\?\C:\policy\headers\H:license"),
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn join_path_loads_headers_and_formats_sources_beyond_max_path() {
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::PathBuf;
+
+    let project = Project::empty();
+    let directory: PathBuf = std::iter::repeat_n("nested-policy-directory", 16).collect();
+    let config_path = directory.join("licenserc.toml");
+    assert!(
+        project
+            .path()
+            .join(&config_path)
+            .as_os_str()
+            .encode_wide()
+            .count()
+            > 260
+    );
+    project.write(
+        &config_path,
+        r#"[header]
+path = "{{ [config_dir, 'headers', 'HEADER.txt'] | join_path }}"
+
+[files]
+root = "{{ [config_dir, 'source'] | join_path }}"
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+    );
+    project.write(directory.join("headers/HEADER.txt"), "Copyright Acme");
+    project.write(directory.join("source/main.rs"), "fn main() {}\n");
+
+    let formatted = project
+        .command(["format", "--output-format=json", "--config"])
+        .arg(config_path)
+        .output()
+        .expect("format sources using long template paths");
+    assert_exit(&formatted, 0);
+    assert_report(&formatted, &[("main.rs", "add")]);
+    assert_eq!(
+        project.read(directory.join("source/main.rs")),
+        "// Copyright Acme\n\nfn main() {}\n"
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/hawkeye/tests/test/paths.rs
+++ b/hawkeye/tests/test/paths.rs
@@ -1,0 +1,369 @@
+// Copyright 2026 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hawkeye::Config;
+use hawkeye::ErrorKind;
+
+use super::support::Project;
+use super::support::assert_exit;
+use super::support::assert_report;
+use super::support::stderr;
+
+#[test]
+fn shared_configs_use_cwd_independently_of_their_location() {
+    for directory in [
+        ".hawkeye",
+        "template/.hawkeye",
+        "template/template/.hawkeye",
+    ] {
+        let project = Project::empty();
+        let config_path = format!("{directory}/licenserc.toml");
+        project.write(
+            &config_path,
+            r#"[header]
+path = "HEADER.txt"
+
+[files]
+root = "{{ cwd }}"
+includes = ["**/*.rs"]
+excludes = ["generated/**"]
+
+[props]
+owner = "Acme"
+
+[git]
+ignore = "disable"
+"#,
+        );
+        project.write(
+            format!("{directory}/HEADER.txt"),
+            "Copyright {{ props.owner }} in {{ attrs.filename }}",
+        );
+        project.write("main.rs", "fn main() {}\n");
+        project.write("generated/ignored.rs", "fn ignored() {}\n");
+        project.write("untouched.txt", "untouched\n");
+
+        let formatted = project
+            .command(["--config", &config_path, "format", "--output-format=json"])
+            .env("PWD", project.path().join(directory))
+            .output()
+            .expect("run with a misleading PWD environment variable");
+        assert_exit(&formatted, 0);
+        assert_report(&formatted, &[("main.rs", "add")]);
+        assert_eq!(
+            project.read("main.rs"),
+            "// Copyright Acme in main.rs\n\nfn main() {}\n"
+        );
+        assert_eq!(project.read("generated/ignored.rs"), "fn ignored() {}\n");
+        assert_eq!(project.read("untouched.txt"), "untouched\n");
+    }
+}
+
+#[test]
+fn defaults_and_relative_results_use_the_config_directory() {
+    let project = Project::empty();
+    for root in ["", "root = '.'", "root = \"{{ '.' }}\""] {
+        project.write(
+            "config/licenserc.toml",
+            format!("[header]\npath = 'HEADER.txt'\n[files]\n{root}\n"),
+        );
+        let path = project.path().join("config/licenserc.toml");
+        let directory = path
+            .canonicalize()
+            .expect("resolve config")
+            .parent()
+            .unwrap()
+            .to_owned();
+        let config = Config::load(path).expect("resolve default or relative root");
+        assert_eq!(config.files.root, directory.join("."));
+        assert_eq!(config.header.path, Some(directory.join("HEADER.txt")));
+    }
+}
+
+#[test]
+fn config_path_and_config_directory_are_absolute_template_values() {
+    let project = Project::empty();
+    project.write(
+        "config/licenserc.toml",
+        r#"[header]
+path = "{{ config_path }}.header"
+
+[files]
+root = "{{ [config_dir, 'source'] | join_path }}"
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+    );
+    project.write("config/licenserc.toml.header", "Copyright Acme");
+    project.write("config/source/main.rs", "fn main() {}\n");
+    project.write("source/outside.rs", "fn outside() {}\n");
+
+    let checked = project.run([
+        "--config",
+        "config/licenserc.toml",
+        "check",
+        "--output-format=json",
+    ]);
+    assert_exit(&checked, 1);
+    assert_report(&checked, &[("main.rs", "add")]);
+}
+
+#[test]
+fn environment_paths_are_rendered_once_before_relative_resolution() {
+    let project = Project::empty();
+    let headers = Project::empty();
+    project.write(
+        "config/licenserc.toml",
+        r#"[header]
+path = "{{ env.HAWKEYE_TEST_HEADER }}"
+
+[files]
+root = "{{ env.HAWKEYE_TEST_ROOT | default(cwd) }}"
+includes = ["**/*.rs"]
+
+[git]
+ignore = "disable"
+"#,
+    );
+    headers.write("HEADER.txt", "Copyright {{ attrs.filename }}");
+    let directory = "source & 'quoted' {{ literal }}";
+    project.write(format!("config/{directory}/main.rs"), "fn main() {}\n");
+
+    for root in [
+        directory.into(),
+        project
+            .path()
+            .join("config")
+            .join(directory)
+            .into_os_string(),
+    ] {
+        let formatted = project
+            .command([
+                "--config",
+                "config/licenserc.toml",
+                "format",
+                "--dry-run",
+                "--output-format=json",
+            ])
+            .env("HAWKEYE_TEST_ROOT", root)
+            .env("HAWKEYE_TEST_HEADER", headers.path().join("HEADER.txt"))
+            .output()
+            .expect("render relative or absolute environment paths");
+        assert_exit(&formatted, 0);
+        assert_report(&formatted, &[("main.rs", "add")]);
+    }
+
+    let fallback = project
+        .command([
+            "--config",
+            "config/licenserc.toml",
+            "check",
+            "--output-format=json",
+        ])
+        .env_remove("HAWKEYE_TEST_ROOT")
+        .env("HAWKEYE_TEST_HEADER", headers.path().join("HEADER.txt"))
+        .output()
+        .expect("use cwd when an optional environment variable is absent");
+    assert_exit(&fallback, 1);
+    assert_report(
+        &fallback,
+        &[(&format!("config/{directory}/main.rs"), "add")],
+    );
+}
+
+#[test]
+fn templated_roots_control_git_discovery_and_requested_paths() {
+    let project = Project::empty();
+    let policy = Project::empty();
+    policy.write(
+        "licenserc.toml",
+        r#"[header]
+path = "{{ [config_dir, 'HEADER.txt'] | join_path }}"
+
+[files]
+root = "{{ [cwd, 'source'] | join_path }}"
+includes = ["**/*.rs"]
+excludes = ["generated/**"]
+
+[git]
+ignore = "enable"
+file_attrs = "enable"
+"#,
+    );
+    policy.write(
+        "HEADER.txt",
+        "Copyright {{ attrs.git_file_created_year }} Acme",
+    );
+    project.write("source/main.rs", "fn main() {}\n");
+    project.write("source/other.rs", "fn other() {}\n");
+    project.write("source/ignored.rs", "fn ignored() {}\n");
+    project.write("source/generated/ignored.rs", "fn generated() {}\n");
+    project.write("outside.rs", "fn outside() {}\n");
+    project.write(".gitignore", "source/ignored.rs\n");
+    project.git(["init", "--initial-branch=main"]);
+    project.git(["add", "source/main.rs"]);
+    project.commit(
+        "add source",
+        "Acme",
+        "acme@example.com",
+        "2020-01-01T00:00:00Z",
+    );
+
+    let checked = project
+        .command(["check", "--output-format=json"])
+        .arg("--config")
+        .arg(policy.path().join("licenserc.toml"))
+        .output()
+        .expect("discover Git from the rendered root");
+    assert_exit(&checked, 1);
+    assert_report(&checked, &[("main.rs", "add"), ("other.rs", "add")]);
+
+    let formatted = project
+        .command([
+            "format",
+            "source/main.rs",
+            "source/generated/ignored.rs",
+            "outside.rs",
+            "--output-format=json",
+        ])
+        .arg("--config")
+        .arg(policy.path().join("licenserc.toml"))
+        .output()
+        .expect("scope requested paths under the rendered root");
+    assert_exit(&formatted, 0);
+    assert_report(&formatted, &[("main.rs", "add")]);
+    assert_eq!(
+        project.read("source/main.rs"),
+        "// Copyright 2020 Acme\n\nfn main() {}\n"
+    );
+    assert_eq!(project.read("source/other.rs"), "fn other() {}\n");
+    assert_eq!(
+        project.read("source/generated/ignored.rs"),
+        "fn generated() {}\n"
+    );
+    assert_eq!(project.read("outside.rs"), "fn outside() {}\n");
+}
+
+#[test]
+fn path_templates_preserve_whitespace_and_allow_literal_delimiters() {
+    let project = Project::empty();
+    let root = " leading & trailing \r\n";
+    project.write(
+        "licenserc.toml",
+        format!(
+            "[header]\npath = '{{% raw %}}{{{{ literal }}}}{{% endraw %}}'\n[files]\nroot = {}\n",
+            toml::Value::String(root.to_owned()),
+        ),
+    );
+    let path = project
+        .path()
+        .join("licenserc.toml")
+        .canonicalize()
+        .expect("resolve config");
+    let config = Config::load(&path).expect("preserve literal path text");
+    let directory = path.parent().unwrap();
+    assert_eq!(config.files.root, directory.join(root));
+    assert_eq!(config.header.path, Some(directory.join("{{ literal }}")));
+}
+
+#[test]
+fn path_template_errors_identify_the_field_and_failing_expression() {
+    let project = Project::empty();
+    for (expression, diagnostic) in [
+        (
+            "{{ missing }}",
+            "undefined value in template expression \"missing\"",
+        ),
+        ("{{", "syntax error"),
+        ("", "empty path"),
+        ("{{ '' }}", "empty path"),
+        ("{{ '\0' }}", "NUL byte"),
+        (
+            "{{ ['source', 42] | join_path }}",
+            "join_path expects a list of strings",
+        ),
+    ] {
+        for field in ["files.root", "header.path"] {
+            let quoted = toml::Value::String(expression.to_owned());
+            let source = if field == "files.root" {
+                format!("[header]\ntext = 'Copyright'\n[files]\nroot = {quoted}\n")
+            } else {
+                format!("[header]\npath = {quoted}\n")
+            };
+            project.write("licenserc.toml", source);
+            let err = Config::load(project.path().join("licenserc.toml"))
+                .expect_err("reject an invalid path template at load time");
+            assert_eq!(err.kind(), ErrorKind::ConfigInvalid);
+            assert!(err.to_string().contains(field), "{err}");
+            assert!(err.to_string().contains(diagnostic), "{err}");
+        }
+    }
+
+    project.write(
+        "licenserc.toml",
+        "[header]\npath = '{{ env.HAWKEYE_TEST_HEADER }}'\n",
+    );
+    let checked = project
+        .command(["check"])
+        .env_remove("HAWKEYE_TEST_HEADER")
+        .output()
+        .expect("report a missing environment variable");
+    assert_exit(&checked, 2);
+    let diagnostic = stderr(&checked);
+    assert!(diagnostic.contains("header.path"), "{diagnostic}");
+    assert!(
+        diagnostic.contains("env.HAWKEYE_TEST_HEADER"),
+        "{diagnostic}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn non_utf8_context_values_fail_only_when_referenced() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let project = Project::named(OsString::from_vec(b"project-\xff".to_vec()));
+    project.write("source/main.rs", "fn main() {}\n");
+    let invalid = OsString::from_vec(b"source-\xff".to_vec());
+    for root in [
+        "source",
+        "{{ 'source' }}",
+        "{{ cwd }}",
+        "{{ config_dir }}",
+        "{{ config_path }}",
+        "{{ env.HAWKEYE_TEST_ROOT }}",
+    ] {
+        project.write(
+            "licenserc.toml",
+            format!("[header]\ntext = 'Copyright'\n[files]\nroot = {}\nincludes = ['**/*.rs']\n[git]\nignore = 'disable'\n", toml::Value::String(root.to_owned())),
+        );
+        let checked = project
+            .command(["check", "--output-format=json"])
+            .env("HAWKEYE_TEST_ROOT", &invalid)
+            .output()
+            .expect("load config with non-UTF-8 native paths and environment values");
+        if root == "source" || root == "{{ 'source' }}" {
+            assert_exit(&checked, 1);
+            assert_report(&checked, &[("main.rs", "add")]);
+        } else {
+            assert_exit(&checked, 2);
+            let diagnostic = stderr(&checked);
+            assert!(diagnostic.contains("files.root"), "{diagnostic}");
+            assert!(diagnostic.contains("not valid UTF-8"), "{diagnostic}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Shared configs currently need a different relative `files.root` at each directory depth. Let them scan the invocation directory while loading a header beside the config. For example, on Unix:

```toml
[files]
root = "{{ cwd }}"

[header]
path = "{{ config_dir }}/HEADER.txt"
```

Path templates expose two variables: `cwd`, the process working directory when loading the config, and `config_dir`, the directory containing the canonical config file. Relative paths retain the existing config-directory base. Environment variables are not exposed, and header contents retain their separate `props` and `attrs` context.

For configs that also run on Windows, use `join_path` when composing paths, such as `{{ [config_dir, 'HEADER.txt'] | join_path }}`. The filter uses native Rust `PathBuf` joining, following [mise's approach](https://github.com/jdx/mise/blob/v2026.9.1/src/tera.rs#L497).

The README explains the shared-config scenario and Windows-compatible path composition; the migration guide shows how to preserve v6's invocation-relative paths. API comments describe the loading contract without repeating the template rules. Markdown conventions are recorded in `AGENTS.md`.

`cargo x lint` passes. The implementation has passed `cargo x test` on Linux, macOS, and Windows with stable Rust and Rust 1.89.0. Regression coverage includes nested shared configs, Git discovery and file selection, template errors, and single-pass rendering. Windows-specific tests cover UNC paths, long-path header loading and formatting, and preservation of named stream paths; Linux also checks non-UTF-8 native directories.

Fixes #227.
