### PR TITLE
chore: prepare v7.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v7.2.0 (2026-09-12)
+
 ### Improvements
 
 * Preserve leading Markdown YAML frontmatter when checking, inserting, updating, or removing license headers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "hawkeye"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "clap",
  "exn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-hawkeye = { version = "7.1.0", path = "hawkeye" }
+hawkeye = { version = "7.2.0", path = "hawkeye" }
 
 # crates.io dependencies
 clap = { version = "4.6.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The default hook installs the matching HawkEye source revision in pre-commit's i
 ```yaml
 repos:
   - repo: https://github.com/fast/hawkeye
-    rev: v7.1.0
+    rev: v7.2.0
     hooks:
       - id: hawkeye-format
 ```

--- a/hawkeye/Cargo.toml
+++ b/hawkeye/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "A license header checker and formatter."
 name = "hawkeye"
-version = "7.1.0"
+version = "7.2.0"
 
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

Prepare v7.2.0 with Markdown YAML frontmatter support (#229). Update the package versions, changelog, and pre-commit example.

Validated with `cargo x build --locked`, `cargo x test` (54 integration tests and 1 doc test), `cargo x lint`, and `dist plan`. Also verified formatting a real skill document preserves its frontmatter and content, including a header removal and reinsertion round trip.
